### PR TITLE
Some fixes in doc comments

### DIFF
--- a/src/requests/answer_pre_checkout_query.rs
+++ b/src/requests/answer_pre_checkout_query.rs
@@ -12,6 +12,8 @@ use crate::{
 /// pre_checkout_query. Use this method to respond to such pre-checkout queries.
 /// On success, True is returned. Note: The Bot API must receive an answer
 /// within 10 seconds after the pre-checkout query was sent.
+///
+/// [`Update`]: crate::types::Update
 pub struct AnswerPreCheckoutQuery<'a> {
     #[serde(skip_serializing)]
     ctx: RequestContext<'a>,

--- a/src/requests/answer_shipping_query.rs
+++ b/src/requests/answer_shipping_query.rs
@@ -11,6 +11,8 @@ use crate::{
 /// is_flexible was specified, the Bot API will send an [`Update`] with a
 /// shipping_query field to the bot. Use this method to reply to shipping
 /// queries. On success, True is returned.
+///
+/// [`Update`]: crate::types::Update
 pub struct AnswerShippingQuery<'a> {
     #[serde(skip_serializing)]
     ctx: RequestContext<'a>,

--- a/src/requests/edit_message_live_location.rs
+++ b/src/requests/edit_message_live_location.rs
@@ -9,9 +9,12 @@ use crate::{
 #[derive(Debug, Clone, Serialize)]
 /// Use this method to edit live location messages. A location can be edited
 /// until its live_period expires or editing is explicitly disabled by a
-/// call to [`stopMessageLiveLocation`]. On success, if the edited message
+/// call to [`StopMessageLiveLocation`]. On success, if the edited message
 /// was sent by the bot, the edited [`Message`] is returned, otherwise True
 /// is returned.
+///
+/// [`StopMessageLiveLocation`]: crate::requests::StopMessageLiveLocation
+/// [`Message`]: crate::types::Message
 pub struct EditMessageLiveLocation<'a> {
     #[serde(skip_serializing)]
     ctx: RequestContext<'a>,

--- a/src/requests/send_audio.rs
+++ b/src/requests/send_audio.rs
@@ -15,6 +15,9 @@ use crate::{
 /// to 50 MB in size, this limit may be changed in the future.
 ///
 /// For sending voice messages, use the [`SendVoice`] method instead.
+///
+/// [`Message`]: crate::types::Message
+/// [`SendVoice`]: crate::requests::SendVoice
 pub struct SendAudio<'a> {
     ctx: RequestContext<'a>,
 
@@ -35,7 +38,7 @@ pub struct SendAudio<'a> {
     /// or inline URLs] in the media caption.
     ///
     /// [Markdown]: crate::types::ParseMode::Markdown
-    /// [Html]: crate::types::ParseMode::Html
+    /// [HTML]: crate::types::ParseMode::HTML
     /// [bold, italic, fixed-width text or inline URLs]:
     /// crate::types::ParseMode
     pub parse_mode: Option<ParseMode>,

--- a/src/requests/send_message.rs
+++ b/src/requests/send_message.rs
@@ -24,7 +24,7 @@ pub struct SendMessage<'a> {
     /// or inline URLs] in the media caption.
     ///
     /// [Markdown]: crate::types::ParseMode::Markdown
-    /// [Html]: crate::types::ParseMode::Html
+    /// [HTML]: crate::types::ParseMode::HTML
     /// [bold, italic, fixed-width text or inline URLs]:
     /// crate::types::ParseMode
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/requests/send_photo.rs
+++ b/src/requests/send_photo.rs
@@ -33,7 +33,7 @@ pub struct SendPhoto<'a> {
     /// or inline URLs] in the media caption.
     ///
     /// [Markdown]: crate::types::ParseMode::Markdown
-    /// [Html]: crate::types::ParseMode::Html
+    /// [HTML]: crate::types::ParseMode::HTML
     /// [bold, italic, fixed-width text or inline URLs]:
     /// crate::types::ParseMode
     pub parse_mode: Option<ParseMode>,

--- a/src/types/force_reply.rs
+++ b/src/types/force_reply.rs
@@ -14,5 +14,7 @@ pub struct ForceReply {
     /// users only. Targets: 1) users that are @mentioned in the text of the
     /// [`Message`] object; 2) if the bot's message is a reply
     /// (has reply_to_message_id), sender of the original message.
+    ///
+    /// [`Message`]: crate::types::Message
     pub selective: Option<bool>,
 }

--- a/src/types/input_media.rs
+++ b/src/types/input_media.rs
@@ -19,7 +19,7 @@ pub enum InputMedia {
         /// or inline URLs] in the media caption.
         ///
         /// [Markdown]: crate::types::ParseMode::Markdown
-        /// [Html]: crate::types::ParseMode::Html
+        /// [HTML]: crate::types::ParseMode::HTML
         /// [bold, italic, fixed-width text or inline URLs]:
         /// crate::types::ParseMode
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -45,7 +45,7 @@ pub enum InputMedia {
         /// or inline URLs] in the media caption.
         ///
         /// [Markdown]: crate::types::ParseMode::Markdown
-        /// [Html]: crate::types::ParseMode::Html
+        /// [HTML]: crate::types::ParseMode::HTML
         /// [bold, italic, fixed-width text or inline URLs]:
         /// crate::types::ParseMode
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -85,7 +85,7 @@ pub enum InputMedia {
         /// or inline URLs] in the media caption.
         ///
         /// [Markdown]: crate::types::ParseMode::Markdown
-        /// [Html]: crate::types::ParseMode::Html
+        /// [HTML]: crate::types::ParseMode::HTML
         /// [bold, italic, fixed-width text or inline URLs]:
         /// crate::types::ParseMode
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -121,7 +121,7 @@ pub enum InputMedia {
         /// or inline URLs] in the media caption.
         ///
         /// [Markdown]: crate::types::ParseMode::Markdown
-        /// [Html]: crate::types::ParseMode::Html
+        /// [HTML]: crate::types::ParseMode::HTML
         /// [bold, italic, fixed-width text or inline URLs]:
         /// crate::types::ParseMode
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -157,7 +157,7 @@ pub enum InputMedia {
         /// or inline URLs] in the media caption.
         ///
         /// [Markdown]: crate::types::ParseMode::Markdown
-        /// [Html]: crate::types::ParseMode::Html
+        /// [HTML]: crate::types::ParseMode::HTML
         /// [bold, italic, fixed-width text or inline URLs]:
         /// crate::types::ParseMode
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/types/input_message_content.rs
+++ b/src/types/input_message_content.rs
@@ -19,7 +19,7 @@ pub enum InputMessageContent {
         /// or inline URLs] in the media caption.
         ///
         /// [Markdown]: crate::types::ParseMode::Markdown
-        /// [Html]: crate::types::ParseMode::Html
+        /// [HTML]: crate::types::ParseMode::HTML
         /// [bold, italic, fixed-width text or inline URLs]:
         /// crate::types::ParseMode
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/types/parse_mode.rs
+++ b/src/types/parse_mode.rs
@@ -28,16 +28,16 @@ use serde::{Deserialize, Serialize};
 ///
 /// Use the following syntax in your message:
 ///
-/// ```ignore
+/// <pre>
 /// *bold text*
 /// _italic text_
 /// [inline URL](http://www.example.com/)
 /// [inline mention of a user](tg://user?id=123456789)
-/// `inline fixed-width code`
+/// &#96;inline fixed-width code&#96;
 /// &#96;&#96;&#96;block_language
 /// pre-formatted fixed-width code block
 /// &#96;&#96;&#96;
-/// ```
+/// </pre>
 ///
 /// ## HTML style
 /// To use this mode, pass [HTML] in the `parse_mode` field when using
@@ -45,14 +45,14 @@ use serde::{Deserialize, Serialize};
 ///
 /// The following tags are currently supported:
 ///
-/// ```ignore
-/// <b>bold</b>, <strong>bold</strong>
-/// <i>italic</i>, <em>italic</em>
-/// <a href="http://www.example.com/">inline URL</a>
-/// <a href="tg://user?id=123456789">inline mention of a user</a>
-/// <code>inline fixed-width code</code>
-/// <pre>pre-formatted fixed-width code block</pre>
-/// ```
+/// <pre>
+/// &lt;b&gt;bold&lt;/b&gt;, &lt;strong&gt;bold&lt;/strong&gt;
+/// &lt;i&gt;italic&lt;/i&gt;, &lt;em&gt;italic&lt;/em&gt;
+/// &lt;a href="http://www.example.com/"&gt;inline URL&lt;/a&gt;
+/// &lt;a href="tg://user?id=123456789"&gt;inline mention of a user&lt;/a&gt;
+/// &lt;code&gt;inline fixed-width code&lt;/code&gt;
+/// &lt;pre&gt;pre-formatted fixed-width code block&lt;/pre&gt;
+/// </pre>
 ///
 /// Please note:
 ///
@@ -64,6 +64,10 @@ use serde::{Deserialize, Serialize};
 /// - All numerical HTML entities are supported.
 /// - The API currently supports only the following named HTML entities: `&lt;`,
 ///   `&gt;`, `&amp;` and `&quot;`.
+///
+/// [Markdown]: crate::types::ParseMode::Markdown
+/// [HTML]: crate::types::ParseMode::HTML
+/// [SendMessage]: crate::requests::SendMessage
 pub enum ParseMode {
     HTML,
     Markdown,

--- a/src/types/photo_size.rs
+++ b/src/types/photo_size.rs
@@ -1,6 +1,9 @@
 #[derive(Debug, Deserialize, Eq, Hash, PartialEq, Serialize, Clone)]
 /// This object represents one size of a photo or a [`Document`] /
 /// [`Sticker`] thumbnail.
+///
+/// [`Document`]: crate::types::Document
+/// [`Sticker`]: crate::types::Sticker
 pub struct PhotoSize {
     /// Identifier for this file
     pub file_id: String,

--- a/src/types/reply_keyboard_markup.rs
+++ b/src/types/reply_keyboard_markup.rs
@@ -5,6 +5,8 @@ use crate::types::KeyboardButton;
 pub struct ReplyKeyboardMarkup {
     /// Array of button rows, each represented by an Array of
     /// [`KeyboardButton`] objects
+    ///
+    /// [`KeyboardButton`]: crate::types::KeyboardButton
     pub keyboard: Vec<Vec<KeyboardButton>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -32,5 +34,7 @@ pub struct ReplyKeyboardMarkup {
     /// Example: A user requests to change the bot‘s language, bot replies to
     /// the request with a keyboard to select the new language. Other users in
     /// the group don’t see the keyboard.
+    ///
+    /// [`Message`]: crate::types::Message
     pub selective: Option<bool>,
 }

--- a/src/types/reply_keyboard_remove.rs
+++ b/src/types/reply_keyboard_remove.rs
@@ -3,6 +3,8 @@
 /// By default, custom keyboards are displayed until a new keyboard is sent
 /// by a bot. An exception is made for one-time keyboards that are hidden
 /// immediately after the user presses a button (see [`ReplyKeyboardMarkup`]).
+///
+/// [`ReplyKeyboardMarkup`]: crate::types::ReplyKeyboardMarkup
 #[derive(Debug, Serialize, Deserialize, Hash, PartialEq, Eq, Clone)]
 pub struct ReplyKeyboardRemove {
     /// equests clients to remove the custom keyboard (user will not be able to
@@ -19,5 +21,7 @@ pub struct ReplyKeyboardRemove {
     /// Example: A user requests to change the bot‘s language, bot replies to
     /// the request with a keyboard to select the new language. Other users in
     /// the group don’t see the keyboard.
+    ///
+    /// [`Message`]: crate::types::Message
     pub selective: Option<bool>,
 }


### PR DESCRIPTION
- Replace 'Html' with 'HTML' in many places
- Add missing links (`[name]: crate::path::to::name`)
- Fix docs for `ParseMode` (use `<pre></pre>`, `&#96;`, `&lt;` and `&gt;` instead of <code>&#96;&#96;&#96;</code>, <code>&#96;</code>, `<` and `>`)