### PR TITLE
Add "unstable-stream" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,8 @@ tokio = "0.2.0-alpha.6"
 bytes = "0.4.12"
 futures-preview = "0.3.0-alpha.19"
 async-trait = "0.1.13"
+
+[features]
+default = []
+
+unstable-stream = [] # add streams to public API

--- a/src/bot/download.rs
+++ b/src/bot/download.rs
@@ -1,11 +1,17 @@
-use tokio::{io::AsyncWrite, stream::Stream};
-use bytes::Bytes;
+use tokio::io::AsyncWrite;
+#[cfg(feature = "unstable-stream")]
+use ::{
+    bytes::Bytes,
+    tokio::stream::Stream,
+};
 
 use crate::{
     bot::Bot,
-    network::{download_file, download_file_stream},
     DownloadError,
+    network::download_file,
 };
+#[cfg(feature = "unstable-stream")]
+use crate::network::download_file_stream;
 
 impl Bot {
     /// Download file from telegram into `destination`.
@@ -56,6 +62,7 @@ impl Bot {
     /// [`AsyncWrite`]: tokio::io::AsyncWrite
     /// [`tokio::fs::File`]: tokio::fs::File
     /// [`download_file`]: crate::bot::Bot::download_file
+    #[cfg(feature = "unstable-stream")]
     pub async fn download_file_stream(
         &self,
         path: &str,

--- a/src/network/download.rs
+++ b/src/network/download.rs
@@ -1,8 +1,9 @@
-use bytes::Bytes;
 use reqwest::Client;
-use tokio::{
-    io::{AsyncWrite, AsyncWriteExt},
-    stream::Stream,
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+#[cfg(feature = "unstable-stream")]
+use ::{
+    tokio::stream::Stream,
+    bytes::Bytes,
 };
 
 use crate::DownloadError;
@@ -31,6 +32,7 @@ where
     Ok(())
 }
 
+#[cfg(feature = "unstable-stream")]
 pub async fn download_file_stream(
     client: &Client,
     token: &str,

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,6 +1,10 @@
-pub use download::{download_file, download_file_stream};
-pub use request::{request_json, request_multipart};
-pub use telegram_response::TelegramResponse;
+pub use self::{
+    download::download_file,
+    request::{request_json, request_multipart},
+    telegram_response::TelegramResponse,
+};
+#[cfg(feature = "unstable-stream")]
+pub use download::download_file_stream;
 
 mod download;
 mod request;
@@ -22,7 +26,7 @@ fn method_url(base: &str, token: &str, method_name: &str) -> String {
 
 /// Creates URL for downloading a file. See the [Telegram documentation].
 ///
-/// [Telegram documentation] (https://core.telegram.org/bots/api#file)
+/// [Telegram documentation]: https://core.telegram.org/bots/api#file
 fn file_url(base: &str, token: &str, file_path: &str) -> String {
     format!(
         "{url}/file/bot{token}/{file}",


### PR DESCRIPTION
Add `unstable-stream` feature that unlocks public API that uses `futures::stream::Stream`