### PR TITLE
Normalise src/requests

### DIFF
--- a/src/bot/api.rs
+++ b/src/bot/api.rs
@@ -22,7 +22,7 @@ impl Bot {
         C: Into<ChatId>,
         T: Into<String>,
     {
-        SendMessage::new(self.ctx(), chat_id.into(), text.into())
+        SendMessage::new(self.ctx(), chat_id, text)
     }
 
     pub fn edit_message_live_location<Lt, Lg>(
@@ -34,11 +34,7 @@ impl Bot {
         Lt: Into<f64>,
         Lg: Into<f64>,
     {
-        EditMessageLiveLocation::new(
-            self.ctx(),
-            latitude.into(),
-            longitude.into(),
-        )
+        EditMessageLiveLocation::new(self.ctx(), latitude, longitude)
     }
 
     pub fn forward_message<C, F, M>(
@@ -52,12 +48,7 @@ impl Bot {
         F: Into<ChatId>,
         M: Into<i32>,
     {
-        ForwardMessage::new(
-            self.ctx(),
-            chat_id.into(),
-            from_chat_id.into(),
-            message_id.into(),
-        )
+        ForwardMessage::new(self.ctx(), chat_id, from_chat_id, message_id)
     }
 
     pub fn send_audio<C, A>(&self, chat_id: C, audio: A) -> SendAudio
@@ -65,7 +56,7 @@ impl Bot {
         C: Into<ChatId>,
         A: Into<InputFile>,
     {
-        SendAudio::new(self.ctx(), chat_id.into(), audio.into())
+        SendAudio::new(self.ctx(), chat_id, audio)
     }
 
     pub fn send_location<C, Lt, Lg>(
@@ -79,12 +70,7 @@ impl Bot {
         Lt: Into<f64>,
         Lg: Into<f64>,
     {
-        SendLocation::new(
-            self.ctx(),
-            chat_id.into(),
-            latitude.into(),
-            longitude.into(),
-        )
+        SendLocation::new(self.ctx(), chat_id, latitude, longitude)
     }
 
     pub fn send_media_group<C, M>(&self, chat_id: C, media: M) -> SendMediaGroup
@@ -92,7 +78,7 @@ impl Bot {
         C: Into<ChatId>,
         M: Into<Vec<InputMedia>>,
     {
-        SendMediaGroup::new(self.ctx(), chat_id.into(), media.into())
+        SendMediaGroup::new(self.ctx(), chat_id, media)
     }
 
     pub fn send_photo<C, P>(&self, chat_id: C, photo: P) -> SendPhoto
@@ -100,7 +86,7 @@ impl Bot {
         C: Into<ChatId>,
         P: Into<InputFile>,
     {
-        SendPhoto::new(self.ctx(), chat_id.into(), photo.into())
+        SendPhoto::new(self.ctx(), chat_id, photo)
     }
 
     pub fn stop_message_live_location(&self) -> StopMessageLiveLocation {
@@ -111,7 +97,7 @@ impl Bot {
     where
         F: Into<String>,
     {
-        GetFile::new(self.ctx(), file_id.into())
+        GetFile::new(self.ctx(), file_id)
     }
 
     pub fn answer_pre_checkout_query<I, O>(
@@ -123,11 +109,7 @@ impl Bot {
         I: Into<String>,
         O: Into<bool>,
     {
-        AnswerPreCheckoutQuery::new(
-            self.ctx(),
-            pre_checkout_query_id.into(),
-            ok.into(),
-        )
+        AnswerPreCheckoutQuery::new(self.ctx(), pre_checkout_query_id, ok)
     }
 
     pub fn answer_shipping_query<I, O>(
@@ -139,11 +121,7 @@ impl Bot {
         I: Into<String>,
         O: Into<bool>,
     {
-        AnswerShippingQuery::new(
-            self.ctx(),
-            shipping_query_id.into(),
-            ok.into(),
-        )
+        AnswerShippingQuery::new(self.ctx(), shipping_query_id, ok)
     }
 
     pub fn kick_chat_member<C, U>(
@@ -155,7 +133,7 @@ impl Bot {
         C: Into<ChatId>,
         U: Into<i32>,
     {
-        KickChatMember::new(self.ctx(), chat_id.into(), user_id.into())
+        KickChatMember::new(self.ctx(), chat_id, user_id)
     }
 
     pub fn pin_chat_message<C, M>(
@@ -167,7 +145,7 @@ impl Bot {
         C: Into<ChatId>,
         M: Into<i32>,
     {
-        PinChatMessage::new(self.ctx(), chat_id.into(), message_id.into())
+        PinChatMessage::new(self.ctx(), chat_id, message_id)
     }
 
     pub fn promote_chat_member<C, U>(
@@ -179,7 +157,7 @@ impl Bot {
         C: Into<ChatId>,
         U: Into<i32>,
     {
-        PromoteChatMember::new(self.ctx(), chat_id.into(), user_id.into())
+        PromoteChatMember::new(self.ctx(), chat_id, user_id)
     }
 
     pub fn restrict_chat_member<C, U, P>(
@@ -193,12 +171,7 @@ impl Bot {
         U: Into<i32>,
         P: Into<ChatPermissions>,
     {
-        RestrictChatMember::new(
-            self.ctx(),
-            chat_id.into(),
-            user_id.into(),
-            permissions.into(),
-        )
+        RestrictChatMember::new(self.ctx(), chat_id, user_id, permissions)
     }
 
     pub fn send_chat_action<C, A>(
@@ -210,7 +183,7 @@ impl Bot {
         C: Into<ChatId>,
         A: Into<ChatAction>,
     {
-        SendChatAction::new(self.ctx(), chat_id.into(), action.into())
+        SendChatAction::new(self.ctx(), chat_id, action)
     }
 
     pub fn send_contact<C, P, F>(
@@ -224,12 +197,7 @@ impl Bot {
         P: Into<String>,
         F: Into<String>,
     {
-        SendContact::new(
-            self.ctx(),
-            chat_id.into(),
-            phone_number.into(),
-            first_name.into(),
-        )
+        SendContact::new(self.ctx(), chat_id, phone_number, first_name)
     }
 
     pub fn send_poll<C, Q, O>(
@@ -243,12 +211,7 @@ impl Bot {
         Q: Into<String>,
         O: Into<Vec<String>>,
     {
-        SendPoll::new(
-            self.ctx(),
-            chat_id.into(),
-            question.into(),
-            options.into(),
-        )
+        SendPoll::new(self.ctx(), chat_id, question, options)
     }
 
     pub fn send_venue<C, Lt, Lg, T, A>(
@@ -266,14 +229,7 @@ impl Bot {
         T: Into<String>,
         A: Into<String>,
     {
-        SendVenue::new(
-            self.ctx(),
-            chat_id.into(),
-            latitude.into(),
-            longitude.into(),
-            title.into(),
-            address.into(),
-        )
+        SendVenue::new(self.ctx(), chat_id, latitude, longitude, title, address)
     }
 
     pub fn send_video_note<C, V>(
@@ -285,7 +241,7 @@ impl Bot {
         C: Into<ChatId>,
         V: Into<String>, // TODO: InputFile
     {
-        SendVideoNote::new(self.ctx(), chat_id.into(), video_note.into())
+        SendVideoNote::new(self.ctx(), chat_id, video_note)
     }
 
     pub fn send_voice<C, V>(&self, chat_id: C, voice: V) -> SendVoice
@@ -293,7 +249,7 @@ impl Bot {
         C: Into<ChatId>,
         V: Into<String>, // TODO: InputFile
     {
-        SendVoice::new(self.ctx(), chat_id.into(), voice.into())
+        SendVoice::new(self.ctx(), chat_id, voice)
     }
 
     pub fn unban_chat_member<C, U>(
@@ -305,13 +261,13 @@ impl Bot {
         C: Into<ChatId>,
         U: Into<i32>,
     {
-        UnbanChatMember::new(self.ctx(), chat_id.into(), user_id.into())
+        UnbanChatMember::new(self.ctx(), chat_id, user_id)
     }
 
     pub fn unpin_chat_message<C>(&self, chat_id: C) -> UnpinChatMessage
     where
         C: Into<ChatId>,
     {
-        UnpinChatMessage::new(self.ctx(), chat_id.into())
+        UnpinChatMessage::new(self.ctx(), chat_id)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 #[macro_use]
-extern crate thiserror;
+extern crate derive_more;
 #[macro_use]
 extern crate serde;
 #[macro_use]
-extern crate derive_more;
+extern crate thiserror;
 
 pub use errors::{DownloadError, RequestError};
 

--- a/src/requests/answer_pre_checkout_query.rs
+++ b/src/requests/answer_pre_checkout_query.rs
@@ -75,27 +75,27 @@ impl<'a> AnswerPreCheckoutQuery<'a> {
         }
     }
 
-    pub fn pre_checkout_query_id<T>(mut self, pre_checkout_query_id: T) -> Self
+    pub fn pre_checkout_query_id<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.pre_checkout_query_id = pre_checkout_query_id.into();
+        self.pre_checkout_query_id = value.into();
         self
     }
 
-    pub fn ok<B>(mut self, ok: B) -> Self
+    pub fn ok<B>(mut self, value: B) -> Self
     where
         B: Into<bool>,
     {
-        self.ok = ok.into();
+        self.ok = value.into();
         self
     }
 
-    pub fn error_message<S>(mut self, error_message: S) -> Self
+    pub fn error_message<S>(mut self, value: S) -> Self
     where
         S: Into<String>,
     {
-        self.error_message = Some(error_message.into());
+        self.error_message = Some(value.into());
         self
     }
 }

--- a/src/requests/answer_pre_checkout_query.rs
+++ b/src/requests/answer_pre_checkout_query.rs
@@ -58,15 +58,19 @@ impl AnswerPreCheckoutQuery<'_> {
 }
 
 impl<'a> AnswerPreCheckoutQuery<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<S, B>(
         ctx: RequestContext<'a>,
-        pre_checkout_query_id: String,
-        ok: bool,
-    ) -> Self {
+        pre_checkout_query_id: S,
+        ok: B,
+    ) -> Self
+    where
+        S: Into<String>,
+        B: Into<bool>,
+    {
         Self {
             ctx,
-            pre_checkout_query_id,
-            ok,
+            pre_checkout_query_id: pre_checkout_query_id.into(),
+            ok: ok.into(),
             error_message: None,
         }
     }
@@ -79,17 +83,17 @@ impl<'a> AnswerPreCheckoutQuery<'a> {
         self
     }
 
-    pub fn ok<T>(mut self, ok: T) -> Self
+    pub fn ok<B>(mut self, ok: B) -> Self
     where
-        T: Into<bool>,
+        B: Into<bool>,
     {
         self.ok = ok.into();
         self
     }
 
-    pub fn error_message<T>(mut self, error_message: T) -> Self
+    pub fn error_message<S>(mut self, error_message: S) -> Self
     where
-        T: Into<String>,
+        S: Into<String>,
     {
         self.error_message = Some(error_message.into());
         self

--- a/src/requests/answer_shipping_query.rs
+++ b/src/requests/answer_shipping_query.rs
@@ -77,35 +77,35 @@ impl<'a> AnswerShippingQuery<'a> {
         }
     }
 
-    pub fn shipping_query_id<S>(mut self, shipping_query_id: S) -> Self
+    pub fn shipping_query_id<S>(mut self, value: S) -> Self
     where
         S: Into<String>,
     {
-        self.shipping_query_id = shipping_query_id.into();
+        self.shipping_query_id = value.into();
         self
     }
 
-    pub fn ok<B>(mut self, ok: B) -> Self
+    pub fn ok<B>(mut self, value: B) -> Self
     where
         B: Into<bool>,
     {
-        self.ok = ok.into();
+        self.ok = value.into();
         self
     }
 
-    pub fn shipping_options<T>(mut self, shipping_options: T) -> Self
+    pub fn shipping_options<T>(mut self, value: T) -> Self
     where
         T: Into<Vec<ShippingOption>>,
     {
-        self.shipping_options = Some(shipping_options.into());
+        self.shipping_options = Some(value.into());
         self
     }
 
-    pub fn error_message<S>(mut self, error_message: S) -> Self
+    pub fn error_message<S>(mut self, value: S) -> Self
     where
         S: Into<String>,
     {
-        self.error_message = Some(error_message.into());
+        self.error_message = Some(value.into());
         self
     }
 }

--- a/src/requests/answer_shipping_query.rs
+++ b/src/requests/answer_shipping_query.rs
@@ -59,31 +59,35 @@ impl AnswerShippingQuery<'_> {
 }
 
 impl<'a> AnswerShippingQuery<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<S, B>(
         ctx: RequestContext<'a>,
-        shipping_query_id: String,
-        ok: bool,
-    ) -> Self {
+        shipping_query_id: S,
+        ok: B,
+    ) -> Self
+    where
+        S: Into<String>,
+        B: Into<bool>,
+    {
         Self {
             ctx,
-            shipping_query_id,
-            ok,
+            shipping_query_id: shipping_query_id.into(),
+            ok: ok.into(),
             shipping_options: None,
             error_message: None,
         }
     }
 
-    pub fn shipping_query_id<T>(mut self, shipping_query_id: T) -> Self
+    pub fn shipping_query_id<S>(mut self, shipping_query_id: S) -> Self
     where
-        T: Into<String>,
+        S: Into<String>,
     {
         self.shipping_query_id = shipping_query_id.into();
         self
     }
 
-    pub fn ok<T>(mut self, ok: T) -> Self
+    pub fn ok<B>(mut self, ok: B) -> Self
     where
-        T: Into<bool>,
+        B: Into<bool>,
     {
         self.ok = ok.into();
         self
@@ -97,9 +101,9 @@ impl<'a> AnswerShippingQuery<'a> {
         self
     }
 
-    pub fn error_message<T>(mut self, error_message: T) -> Self
+    pub fn error_message<S>(mut self, error_message: S) -> Self
     where
-        T: Into<String>,
+        S: Into<String>,
     {
         self.error_message = Some(error_message.into());
         self

--- a/src/requests/edit_message_live_location.rs
+++ b/src/requests/edit_message_live_location.rs
@@ -83,43 +83,43 @@ impl<'a> EditMessageLiveLocation<'a> {
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = Some(chat_id.into());
+        self.chat_id = Some(value.into());
         self
     }
 
-    pub fn message_id<T>(mut self, message_id: T) -> Self
+    pub fn message_id<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.message_id = Some(message_id.into());
+        self.message_id = Some(value.into());
         self
     }
 
-    pub fn inline_message_id<S>(mut self, inline_message_id: S) -> Self
+    pub fn inline_message_id<S>(mut self, value: S) -> Self
     where
         S: Into<String>,
     {
-        self.inline_message_id = Some(inline_message_id.into());
+        self.inline_message_id = Some(value.into());
         self
     }
 
-    pub fn latitude<Lt>(mut self, latitude: Lt) -> Self
+    pub fn latitude<Lt>(mut self, value: Lt) -> Self
     where
         Lt: Into<f64>,
     {
-        self.latitude = latitude.into();
+        self.latitude = value.into();
         self
     }
 
-    pub fn longitude<Lg>(mut self, longitude: Lg) -> Self
+    pub fn longitude<Lg>(mut self, value: Lg) -> Self
     where
         Lg: Into<f64>,
     {
-        self.longitude = longitude.into();
+        self.longitude = value.into();
         self
     }
 }

--- a/src/requests/edit_message_live_location.rs
+++ b/src/requests/edit_message_live_location.rs
@@ -63,46 +63,62 @@ impl EditMessageLiveLocation<'_> {
 }
 
 impl<'a> EditMessageLiveLocation<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<Lt, Lg>(
         ctx: RequestContext<'a>,
-        latitude: f64,
-        longitude: f64,
-    ) -> Self {
+        latitude: Lt,
+        longitude: Lg,
+    ) -> Self
+    where
+        Lt: Into<f64>,
+        Lg: Into<f64>,
+    {
         Self {
             ctx,
             chat_id: None,
             message_id: None,
             inline_message_id: None,
-            latitude,
-            longitude,
+            latitude: latitude.into(),
+            longitude: longitude.into(),
             reply_markup: None,
         }
     }
 
-    pub fn chat_id<T: Into<ChatId>>(mut self, chat_id: T) -> Self {
+    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    where
+        T: Into<ChatId>,
+    {
         self.chat_id = Some(chat_id.into());
         self
     }
 
-    pub fn message_id<T: Into<i32>>(mut self, message_id: T) -> Self {
+    pub fn message_id<T>(mut self, message_id: T) -> Self
+    where
+        T: Into<i32>,
+    {
         self.message_id = Some(message_id.into());
         self
     }
 
-    pub fn inline_message_id<T>(mut self, inline_message_id: T) -> Self
+    pub fn inline_message_id<S>(mut self, inline_message_id: S) -> Self
     where
-        T: Into<String>,
+        S: Into<String>,
     {
         self.inline_message_id = Some(inline_message_id.into());
         self
     }
 
-    pub fn latitude<T: Into<f64>>(mut self, latitude: T) -> Self {
+    pub fn latitude<Lt>(mut self, latitude: Lt) -> Self
+    where
+        Lt: Into<f64>,
+    {
         self.latitude = latitude.into();
         self
     }
 
-    pub fn longitude<T: Into<f64>>(mut self, longitude: T) -> Self {
+    pub fn longitude<Lg>(mut self, longitude: Lg) -> Self
+    where
+        Lg: Into<f64>,
+    {
         self.longitude = longitude.into();
         self
     }

--- a/src/requests/forward_message.rs
+++ b/src/requests/forward_message.rs
@@ -50,38 +50,55 @@ impl ForwardMessage<'_> {
 }
 
 impl<'a> ForwardMessage<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<C, Fc, M>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        from_chat_id: ChatId,
-        message_id: i32,
-    ) -> Self {
+        chat_id: C,
+        from_chat_id: Fc,
+        message_id: M,
+    ) -> Self
+    where
+        C: Into<ChatId>,
+        Fc: Into<ChatId>,
+        M: Into<i32>,
+    {
         Self {
             ctx,
-            chat_id,
-            from_chat_id,
-            message_id,
+            chat_id: chat_id.into(),
+            from_chat_id: from_chat_id.into(),
+            message_id: message_id.into(),
             disable_notification: None,
         }
     }
 
-    pub fn chat_id<T: Into<ChatId>>(mut self, val: T) -> Self {
-        self.chat_id = val.into();
+    pub fn chat_id<C>(mut self, chat_id: C) -> Self
+    where
+        C: Into<ChatId>,
+    {
+        self.chat_id = chat_id.into();
         self
     }
 
-    pub fn from_chat_id<T: Into<ChatId>>(mut self, val: T) -> Self {
-        self.from_chat_id = val.into();
+    pub fn from_chat_id<C>(mut self, from_chat_id: C) -> Self
+    where
+        C: Into<ChatId>,
+    {
+        self.from_chat_id = from_chat_id.into();
         self
     }
 
-    pub fn message_id<T: Into<i32>>(mut self, val: T) -> Self {
-        self.message_id = val.into();
+    pub fn message_id<M>(mut self, message_id: M) -> Self
+    where
+        M: Into<i32>,
+    {
+        self.message_id = message_id.into();
         self
     }
 
-    pub fn disable_notification<T: Into<bool>>(mut self, val: T) -> Self {
-        self.disable_notification = Some(val.into());
+    pub fn disable_notification<B>(mut self, disable_notification: B) -> Self
+    where
+        B: Into<bool>,
+    {
+        self.disable_notification = Some(disable_notification.into());
         self
     }
 }

--- a/src/requests/forward_message.rs
+++ b/src/requests/forward_message.rs
@@ -70,35 +70,35 @@ impl<'a> ForwardMessage<'a> {
         }
     }
 
-    pub fn chat_id<C>(mut self, chat_id: C) -> Self
+    pub fn chat_id<C>(mut self, value: C) -> Self
     where
         C: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn from_chat_id<C>(mut self, from_chat_id: C) -> Self
+    pub fn from_chat_id<C>(mut self, value: C) -> Self
     where
         C: Into<ChatId>,
     {
-        self.from_chat_id = from_chat_id.into();
+        self.from_chat_id = value.into();
         self
     }
 
-    pub fn message_id<M>(mut self, message_id: M) -> Self
+    pub fn message_id<M>(mut self, value: M) -> Self
     where
         M: Into<i32>,
     {
-        self.message_id = message_id.into();
+        self.message_id = value.into();
         self
     }
 
-    pub fn disable_notification<B>(mut self, disable_notification: B) -> Self
+    pub fn disable_notification<B>(mut self, value: B) -> Self
     where
         B: Into<bool>,
     {
-        self.disable_notification = Some(disable_notification.into());
+        self.disable_notification = Some(value.into());
         self
     }
 }

--- a/src/requests/get_chat.rs
+++ b/src/requests/get_chat.rs
@@ -41,9 +41,9 @@ impl GetChat<'_> {
 }
 
 impl<'a> GetChat<'a> {
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<C>(mut self, chat_id: C) -> Self
     where
-        T: Into<ChatId>,
+        C: Into<ChatId>,
     {
         self.chat_id = chat_id.into();
         self

--- a/src/requests/get_chat.rs
+++ b/src/requests/get_chat.rs
@@ -41,11 +41,11 @@ impl GetChat<'_> {
 }
 
 impl<'a> GetChat<'a> {
-    pub fn chat_id<C>(mut self, chat_id: C) -> Self
+    pub fn chat_id<C>(mut self, value: C) -> Self
     where
         C: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 }

--- a/src/requests/get_file.rs
+++ b/src/requests/get_file.rs
@@ -43,21 +43,21 @@ impl GetFile<'_> {
 }
 
 impl<'a> GetFile<'a> {
-    pub(crate) fn new<F>(ctx: RequestContext<'a>, file_id: F) -> Self
+    pub(crate) fn new<F>(ctx: RequestContext<'a>, value: F) -> Self
     where
         F: Into<String>,
     {
         Self {
             ctx,
-            file_id: file_id.into(),
+            file_id: value.into(),
         }
     }
 
-    pub fn file_id<F>(mut self, file_id: F) -> Self
+    pub fn file_id<F>(mut self, value: F) -> Self
     where
         F: Into<String>,
     {
-        self.file_id = file_id.into();
+        self.file_id = value.into();
         self
     }
 }

--- a/src/requests/get_file.rs
+++ b/src/requests/get_file.rs
@@ -43,13 +43,19 @@ impl GetFile<'_> {
 }
 
 impl<'a> GetFile<'a> {
-    pub(crate) fn new(ctx: RequestContext<'a>, file_id: String) -> Self {
-        Self { ctx, file_id }
+    pub(crate) fn new<F>(ctx: RequestContext<'a>, file_id: F) -> Self
+    where
+        F: Into<String>,
+    {
+        Self {
+            ctx,
+            file_id: file_id.into(),
+        }
     }
 
-    pub fn file_id<T>(mut self, file_id: T) -> Self
+    pub fn file_id<F>(mut self, file_id: F) -> Self
     where
-        T: Into<String>,
+        F: Into<String>,
     {
         self.file_id = file_id.into();
         self

--- a/src/requests/get_updates.rs
+++ b/src/requests/get_updates.rs
@@ -61,35 +61,35 @@ impl<'a> GetUpdates<'a> {
         }
     }
 
-    pub fn offset<T>(mut self, offset: T) -> Self
+    pub fn offset<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.offset = Some(offset.into());
+        self.offset = Some(value.into());
         self
     }
 
-    pub fn limit<T>(mut self, limit: T) -> Self
+    pub fn limit<T>(mut self, value: T) -> Self
     where
         T: Into<u8>,
     {
-        self.limit = Some(limit.into());
+        self.limit = Some(value.into());
         self
     }
 
-    pub fn timeout<T>(mut self, timeout: T) -> Self
+    pub fn timeout<T>(mut self, value: T) -> Self
     where
         T: Into<u32>,
     {
-        self.timeout = Some(timeout.into());
+        self.timeout = Some(value.into());
         self
     }
 
-    pub fn allowed_updates<T>(mut self, allowed_updates: T) -> Self
+    pub fn allowed_updates<T>(mut self, value: T) -> Self
     where
         T: Into<Vec<AllowedUpdate>>,
     {
-        self.allowed_updates = Some(allowed_updates.into());
+        self.allowed_updates = Some(value.into());
         self
     }
 }

--- a/src/requests/get_user_profile_photos.rs
+++ b/src/requests/get_user_profile_photos.rs
@@ -46,10 +46,13 @@ impl GetUserProfilePhotos<'_> {
 }
 
 impl<'a> GetUserProfilePhotos<'a> {
-    pub fn new(ctx: RequestContext<'a>, user_id: i32) -> Self {
+    pub fn new<U>(ctx: RequestContext<'a>, user_id: U) -> Self
+    where
+        U: Into<i32>,
+    {
         Self {
             ctx,
-            user_id,
+            user_id: user_id.into(),
             offset: None,
             limit: None,
         }

--- a/src/requests/get_user_profile_photos.rs
+++ b/src/requests/get_user_profile_photos.rs
@@ -58,27 +58,27 @@ impl<'a> GetUserProfilePhotos<'a> {
         }
     }
 
-    pub fn user_id<T>(mut self, user_id: T) -> Self
+    pub fn user_id<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.user_id = user_id.into();
+        self.user_id = value.into();
         self
     }
 
-    pub fn offset<T>(mut self, offset: T) -> Self
+    pub fn offset<T>(mut self, value: T) -> Self
     where
         T: Into<i64>,
     {
-        self.offset = Some(offset.into());
+        self.offset = Some(value.into());
         self
     }
 
-    pub fn limit<T>(mut self, limit: T) -> Self
+    pub fn limit<T>(mut self, value: T) -> Self
     where
         T: Into<i64>,
     {
-        self.limit = Some(limit.into());
+        self.limit = Some(value.into());
         self
     }
 }

--- a/src/requests/kick_chat_member.rs
+++ b/src/requests/kick_chat_member.rs
@@ -49,30 +49,43 @@ impl KickChatMember<'_> {
 }
 
 impl<'a> KickChatMember<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<C, U>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        user_id: i32,
-    ) -> Self {
+        chat_id: C,
+        user_id: U,
+    ) -> Self
+    where
+        C: Into<ChatId>,
+        U: Into<i32>,
+    {
         Self {
             ctx,
-            chat_id,
-            user_id,
+            chat_id: chat_id.into(),
+            user_id: user_id.into(),
             until_date: None,
         }
     }
 
-    pub fn chat_id<T: Into<ChatId>>(mut self, chat_id: T) -> Self {
+    pub fn chat_id<C>(mut self, chat_id: C) -> Self
+    where
+        C: Into<ChatId>,
+    {
         self.chat_id = chat_id.into();
         self
     }
 
-    pub fn user_id<T: Into<i32>>(mut self, user_id: T) -> Self {
+    pub fn user_id<U>(mut self, user_id: U) -> Self
+    where
+        U: Into<i32>,
+    {
         self.user_id = user_id.into();
         self
     }
 
-    pub fn until_date<T: Into<u64>>(mut self, until_date: T) -> Self {
+    pub fn until_date<T>(mut self, until_date: T) -> Self
+    where
+        T: Into<u64>,
+    {
         self.until_date = Some(until_date.into());
         self
     }

--- a/src/requests/kick_chat_member.rs
+++ b/src/requests/kick_chat_member.rs
@@ -66,27 +66,27 @@ impl<'a> KickChatMember<'a> {
         }
     }
 
-    pub fn chat_id<C>(mut self, chat_id: C) -> Self
+    pub fn chat_id<C>(mut self, value: C) -> Self
     where
         C: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn user_id<U>(mut self, user_id: U) -> Self
+    pub fn user_id<U>(mut self, value: U) -> Self
     where
         U: Into<i32>,
     {
-        self.user_id = user_id.into();
+        self.user_id = value.into();
         self
     }
 
-    pub fn until_date<T>(mut self, until_date: T) -> Self
+    pub fn until_date<T>(mut self, value: T) -> Self
     where
         T: Into<u64>,
     {
-        self.until_date = Some(until_date.into());
+        self.until_date = Some(value.into());
         self
     }
 }

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -1,3 +1,30 @@
+use reqwest::Client;
+use serde::de::DeserializeOwned;
+
+use async_trait::async_trait;
+
+use crate::RequestError;
+
+pub use self::{
+    answer_pre_checkout_query::AnswerPreCheckoutQuery,
+    answer_shipping_query::AnswerShippingQuery,
+    edit_message_live_location::EditMessageLiveLocation,
+    forward_message::ForwardMessage, get_chat::GetChat, get_file::GetFile,
+    get_me::GetMe, get_updates::GetUpdates,
+    get_user_profile_photos::GetUserProfilePhotos,
+    kick_chat_member::KickChatMember, pin_chat_message::PinChatMessage,
+    promote_chat_member::PromoteChatMember,
+    restrict_chat_member::RestrictChatMember, send_animation::SendAnimation,
+    send_audio::SendAudio, send_chat_action::SendChatAction,
+    send_contact::SendContact, send_document::SendDocument,
+    send_location::SendLocation, send_media_group::SendMediaGroup,
+    send_message::SendMessage, send_photo::SendPhoto, send_poll::SendPoll,
+    send_venue::SendVenue, send_video::SendVideo,
+    send_video_note::SendVideoNote, send_voice::SendVoice,
+    stop_message_live_location::StopMessageLiveLocation,
+    unban_chat_member::UnbanChatMember, unpin_chat_message::UnpinChatMessage,
+};
+
 mod form_builder;
 mod utils;
 
@@ -31,32 +58,6 @@ mod send_voice;
 mod stop_message_live_location;
 mod unban_chat_member;
 mod unpin_chat_message;
-
-use async_trait::async_trait;
-use reqwest::Client;
-use serde::de::DeserializeOwned;
-
-use crate::RequestError;
-
-pub use self::{
-    answer_pre_checkout_query::AnswerPreCheckoutQuery,
-    answer_shipping_query::AnswerShippingQuery,
-    edit_message_live_location::EditMessageLiveLocation,
-    forward_message::ForwardMessage, get_chat::GetChat, get_file::GetFile,
-    get_me::GetMe, get_updates::GetUpdates,
-    get_user_profile_photos::GetUserProfilePhotos,
-    kick_chat_member::KickChatMember, pin_chat_message::PinChatMessage,
-    promote_chat_member::PromoteChatMember,
-    restrict_chat_member::RestrictChatMember, send_animation::SendAnimation,
-    send_audio::SendAudio, send_chat_action::SendChatAction,
-    send_contact::SendContact, send_document::SendDocument,
-    send_location::SendLocation, send_media_group::SendMediaGroup,
-    send_message::SendMessage, send_photo::SendPhoto, send_poll::SendPoll,
-    send_venue::SendVenue, send_video::SendVideo,
-    send_video_note::SendVideoNote, send_voice::SendVoice,
-    stop_message_live_location::StopMessageLiveLocation,
-    unban_chat_member::UnbanChatMember, unpin_chat_message::UnpinChatMessage,
-};
 
 pub type ResponseResult<T> = Result<T, RequestError>;
 

--- a/src/requests/pin_chat_message.rs
+++ b/src/requests/pin_chat_message.rs
@@ -22,24 +22,28 @@ pub struct PinChatMessage<'a> {
 }
 
 impl<'a> PinChatMessage<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<C, M>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        message_id: i32,
-    ) -> Self {
+        chat_id: C,
+        message_id: M,
+    ) -> Self
+    where
+        C: Into<ChatId>,
+        M: Into<i32>,
+    {
         Self {
             ctx,
-            chat_id,
-            message_id,
+            chat_id: chat_id.into(),
+            message_id: message_id.into(),
             disable_notification: None,
         }
     }
 
-    pub fn disable_notification<T>(mut self, val: T) -> Self
+    pub fn disable_notification<B>(mut self, disable_notification: B) -> Self
     where
-        T: Into<bool>,
+        B: Into<bool>,
     {
-        self.disable_notification = Some(val.into());
+        self.disable_notification = Some(disable_notification.into());
         self
     }
 }

--- a/src/requests/pin_chat_message.rs
+++ b/src/requests/pin_chat_message.rs
@@ -39,11 +39,11 @@ impl<'a> PinChatMessage<'a> {
         }
     }
 
-    pub fn disable_notification<B>(mut self, disable_notification: B) -> Self
+    pub fn disable_notification<B>(mut self, value: B) -> Self
     where
         B: Into<bool>,
     {
-        self.disable_notification = Some(disable_notification.into());
+        self.disable_notification = Some(value.into());
         self
     }
 }

--- a/src/requests/promote_chat_member.rs
+++ b/src/requests/promote_chat_member.rs
@@ -72,15 +72,19 @@ impl PromoteChatMember<'_> {
 }
 
 impl<'a> PromoteChatMember<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<C, U>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        user_id: i32,
-    ) -> Self {
+        chat_id: C,
+        user_id: U,
+    ) -> Self
+    where
+        C: Into<ChatId>,
+        U: Into<i32>,
+    {
         Self {
             ctx,
-            chat_id,
-            user_id,
+            chat_id: chat_id.into(),
+            user_id: user_id.into(),
             can_change_info: None,
             can_post_messages: None,
             can_edit_messages: None,
@@ -92,81 +96,81 @@ impl<'a> PromoteChatMember<'a> {
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<C>(mut self, chat_id: C) -> Self
     where
-        T: Into<ChatId>,
+        C: Into<ChatId>,
     {
         self.chat_id = chat_id.into();
         self
     }
 
-    pub fn user_id<T>(mut self, user_id: T) -> Self
+    pub fn user_id<U>(mut self, user_id: U) -> Self
     where
-        T: Into<i32>,
+        U: Into<i32>,
     {
         self.user_id = user_id.into();
         self
     }
 
-    pub fn can_change_info<T>(mut self, can_change_info: T) -> Self
+    pub fn can_change_info<B>(mut self, can_change_info: B) -> Self
     where
-        T: Into<bool>,
+        B: Into<bool>,
     {
         self.can_change_info = Some(can_change_info.into());
         self
     }
 
-    pub fn can_post_messages<T>(mut self, can_post_messages: T) -> Self
+    pub fn can_post_messages<B>(mut self, can_post_messages: B) -> Self
     where
-        T: Into<bool>,
+        B: Into<bool>,
     {
         self.can_post_messages = Some(can_post_messages.into());
         self
     }
 
-    pub fn can_edit_messages<T>(mut self, can_edit_messages: T) -> Self
+    pub fn can_edit_messages<B>(mut self, can_edit_messages: B) -> Self
     where
-        T: Into<bool>,
+        B: Into<bool>,
     {
         self.can_edit_messages = Some(can_edit_messages.into());
         self
     }
 
-    pub fn can_delete_messages<T>(mut self, can_delete_messages: T) -> Self
+    pub fn can_delete_messages<B>(mut self, can_delete_messages: B) -> Self
     where
-        T: Into<bool>,
+        B: Into<bool>,
     {
         self.can_delete_messages = Some(can_delete_messages.into());
         self
     }
 
-    pub fn can_invite_users<T>(mut self, can_invite_users: T) -> Self
+    pub fn can_invite_users<B>(mut self, can_invite_users: B) -> Self
     where
-        T: Into<bool>,
+        B: Into<bool>,
     {
         self.can_invite_users = Some(can_invite_users.into());
         self
     }
 
-    pub fn can_restrict_members<T>(mut self, can_restrict_members: T) -> Self
+    pub fn can_restrict_members<B>(mut self, can_restrict_members: B) -> Self
     where
-        T: Into<bool>,
+        B: Into<bool>,
     {
         self.can_restrict_members = Some(can_restrict_members.into());
         self
     }
 
-    pub fn can_pin_messages<T>(mut self, can_pin_messages: T) -> Self
+    pub fn can_pin_messages<B>(mut self, can_pin_messages: B) -> Self
     where
-        T: Into<bool>,
+        B: Into<bool>,
     {
         self.can_pin_messages = Some(can_pin_messages.into());
         self
     }
 
-    pub fn can_promote_members<T>(mut self, can_promote_members: T) -> Self
+    pub fn can_promote_members<B>(mut self, can_promote_members: B) -> Self
     where
-        T: Into<bool>,
+        B: Into<bool>,
     {
         self.can_promote_members = Some(can_promote_members.into());
         self

--- a/src/requests/promote_chat_member.rs
+++ b/src/requests/promote_chat_member.rs
@@ -96,83 +96,83 @@ impl<'a> PromoteChatMember<'a> {
         }
     }
 
-    pub fn chat_id<C>(mut self, chat_id: C) -> Self
+    pub fn chat_id<C>(mut self, value: C) -> Self
     where
         C: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn user_id<U>(mut self, user_id: U) -> Self
+    pub fn user_id<U>(mut self, value: U) -> Self
     where
         U: Into<i32>,
     {
-        self.user_id = user_id.into();
+        self.user_id = value.into();
         self
     }
 
-    pub fn can_change_info<B>(mut self, can_change_info: B) -> Self
+    pub fn can_change_info<B>(mut self, value: B) -> Self
     where
         B: Into<bool>,
     {
-        self.can_change_info = Some(can_change_info.into());
+        self.can_change_info = Some(value.into());
         self
     }
 
-    pub fn can_post_messages<B>(mut self, can_post_messages: B) -> Self
+    pub fn can_post_messages<B>(mut self, value: B) -> Self
     where
         B: Into<bool>,
     {
-        self.can_post_messages = Some(can_post_messages.into());
+        self.can_post_messages = Some(value.into());
         self
     }
 
-    pub fn can_edit_messages<B>(mut self, can_edit_messages: B) -> Self
+    pub fn can_edit_messages<B>(mut self, value: B) -> Self
     where
         B: Into<bool>,
     {
-        self.can_edit_messages = Some(can_edit_messages.into());
+        self.can_edit_messages = Some(value.into());
         self
     }
 
-    pub fn can_delete_messages<B>(mut self, can_delete_messages: B) -> Self
+    pub fn can_delete_messages<B>(mut self, value: B) -> Self
     where
         B: Into<bool>,
     {
-        self.can_delete_messages = Some(can_delete_messages.into());
+        self.can_delete_messages = Some(value.into());
         self
     }
 
-    pub fn can_invite_users<B>(mut self, can_invite_users: B) -> Self
+    pub fn can_invite_users<B>(mut self, value: B) -> Self
     where
         B: Into<bool>,
     {
-        self.can_invite_users = Some(can_invite_users.into());
+        self.can_invite_users = Some(value.into());
         self
     }
 
-    pub fn can_restrict_members<B>(mut self, can_restrict_members: B) -> Self
+    pub fn can_restrict_members<B>(mut self, value: B) -> Self
     where
         B: Into<bool>,
     {
-        self.can_restrict_members = Some(can_restrict_members.into());
+        self.can_restrict_members = Some(value.into());
         self
     }
 
-    pub fn can_pin_messages<B>(mut self, can_pin_messages: B) -> Self
+    pub fn can_pin_messages<B>(mut self, value: B) -> Self
     where
         B: Into<bool>,
     {
-        self.can_pin_messages = Some(can_pin_messages.into());
+        self.can_pin_messages = Some(value.into());
         self
     }
 
-    pub fn can_promote_members<B>(mut self, can_promote_members: B) -> Self
+    pub fn can_promote_members<B>(mut self, value: B) -> Self
     where
         B: Into<bool>,
     {
-        self.can_promote_members = Some(can_promote_members.into());
+        self.can_promote_members = Some(value.into());
         self
     }
 }

--- a/src/requests/restrict_chat_member.rs
+++ b/src/requests/restrict_chat_member.rs
@@ -50,40 +50,45 @@ impl RestrictChatMember<'_> {
 }
 
 impl<'a> RestrictChatMember<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<C, U, P>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        user_id: i32,
-        permissions: ChatPermissions,
-    ) -> Self {
+        chat_id: C,
+        user_id: U,
+        permissions: P,
+    ) -> Self
+    where
+        C: Into<ChatId>,
+        U: Into<i32>,
+        P: Into<ChatPermissions>,
+    {
         Self {
             ctx,
-            chat_id,
-            user_id,
-            permissions,
+            chat_id: chat_id.into(),
+            user_id: user_id.into(),
+            permissions: permissions.into(),
             until_date: None,
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<C>(mut self, chat_id: C) -> Self
     where
-        T: Into<ChatId>,
+        C: Into<ChatId>,
     {
         self.chat_id = chat_id.into();
         self
     }
 
-    pub fn user_id<T>(mut self, user_id: T) -> Self
+    pub fn user_id<U>(mut self, user_id: U) -> Self
     where
-        T: Into<i32>,
+        U: Into<i32>,
     {
         self.user_id = user_id.into();
         self
     }
 
-    pub fn permissions<T>(mut self, permissions: T) -> Self
+    pub fn permissions<P>(mut self, permissions: P) -> Self
     where
-        T: Into<ChatPermissions>,
+        P: Into<ChatPermissions>,
     {
         self.permissions = permissions.into();
         self

--- a/src/requests/restrict_chat_member.rs
+++ b/src/requests/restrict_chat_member.rs
@@ -70,35 +70,35 @@ impl<'a> RestrictChatMember<'a> {
         }
     }
 
-    pub fn chat_id<C>(mut self, chat_id: C) -> Self
+    pub fn chat_id<C>(mut self, value: C) -> Self
     where
         C: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn user_id<U>(mut self, user_id: U) -> Self
+    pub fn user_id<U>(mut self, value: U) -> Self
     where
         U: Into<i32>,
     {
-        self.user_id = user_id.into();
+        self.user_id = value.into();
         self
     }
 
-    pub fn permissions<P>(mut self, permissions: P) -> Self
+    pub fn permissions<P>(mut self, value: P) -> Self
     where
         P: Into<ChatPermissions>,
     {
-        self.permissions = permissions.into();
+        self.permissions = value.into();
         self
     }
 
-    pub fn until_date<T>(mut self, until_date: T) -> Self
+    pub fn until_date<T>(mut self, value: T) -> Self
     where
         T: Into<u64>,
     {
-        self.until_date = Some(until_date.into());
+        self.until_date = Some(value.into());
         self
     }
 }

--- a/src/requests/send_animation.rs
+++ b/src/requests/send_animation.rs
@@ -86,15 +86,19 @@ impl SendAnimation<'_> {
 }
 
 impl<'a> SendAnimation<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<C, S>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        animation: String,
-    ) -> Self {
+        chat_id: C,
+        animation: S,
+    ) -> Self
+    where
+        C: Into<ChatId>,
+        S: Into<String>,
+    {
         Self {
             ctx,
-            chat_id,
-            animation,
+            chat_id: chat_id.into(),
+            animation: animation.into(),
             duration: None,
             width: None,
             height: None,

--- a/src/requests/send_animation.rs
+++ b/src/requests/send_animation.rs
@@ -111,76 +111,76 @@ impl<'a> SendAnimation<'a> {
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn duration<T>(mut self, duration: T) -> Self
+    pub fn duration<T>(mut self, value: T) -> Self
     where
         T: Into<u64>,
     {
-        self.duration = Some(duration.into());
+        self.duration = Some(value.into());
         self
     }
 
-    pub fn width<T>(mut self, width: T) -> Self
+    pub fn width<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.width = Some(width.into());
+        self.width = Some(value.into());
         self
     }
-    pub fn height<T>(mut self, height: T) -> Self
+    pub fn height<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.height = Some(height.into());
+        self.height = Some(value.into());
         self
     }
-    pub fn thumb<T>(mut self, thumb: T) -> Self
+    pub fn thumb<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.thumb = Some(thumb.into());
+        self.thumb = Some(value.into());
         self
     }
-    pub fn caption<T>(mut self, caption: T) -> Self
+    pub fn caption<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.caption = Some(caption.into());
+        self.caption = Some(value.into());
         self
     }
-    pub fn parse_mode<T>(mut self, parse_mode: T) -> Self
+    pub fn parse_mode<T>(mut self, value: T) -> Self
     where
         T: Into<ParseMode>,
     {
-        self.parse_mode = Some(parse_mode.into());
+        self.parse_mode = Some(value.into());
         self
     }
-    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    pub fn disable_notification<T>(mut self, value: T) -> Self
     where
         T: Into<bool>,
     {
-        self.disable_notification = Some(disable_notification.into());
+        self.disable_notification = Some(value.into());
         self
     }
-    pub fn reply_to_message_id<T>(mut self, reply_to_message_id: T) -> Self
+    pub fn reply_to_message_id<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.reply_to_message_id = Some(reply_to_message_id.into());
+        self.reply_to_message_id = Some(value.into());
         self
     }
-    pub fn reply_markup<T>(mut self, reply_markup: T) -> Self
+    pub fn reply_markup<T>(mut self, value: T) -> Self
     where
         T: Into<ReplyMarkup>,
     {
-        self.reply_markup = Some(reply_markup.into());
+        self.reply_markup = Some(value.into());
         self
     }
 }

--- a/src/requests/send_audio.rs
+++ b/src/requests/send_audio.rs
@@ -140,83 +140,83 @@ impl<'a> SendAudio<'a> {
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn audio<T>(mut self, audio: T) -> Self
+    pub fn audio<T>(mut self, value: T) -> Self
     where
         T: Into<InputFile>,
     {
-        self.audio = audio.into();
+        self.audio = value.into();
         self
     }
 
-    pub fn caption<T>(mut self, caption: T) -> Self
+    pub fn caption<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.caption = Some(caption.into());
+        self.caption = Some(value.into());
         self
     }
 
-    pub fn parse_mode<T>(mut self, parse_mode: T) -> Self
+    pub fn parse_mode<T>(mut self, value: T) -> Self
     where
         T: Into<ParseMode>,
     {
-        self.parse_mode = Some(parse_mode.into());
+        self.parse_mode = Some(value.into());
         self
     }
 
-    pub fn duration<T>(mut self, duration: T) -> Self
+    pub fn duration<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.duration = Some(duration.into());
+        self.duration = Some(value.into());
         self
     }
 
-    pub fn performer<T>(mut self, performer: T) -> Self
+    pub fn performer<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.performer = Some(performer.into());
+        self.performer = Some(value.into());
         self
     }
 
-    pub fn title<T>(mut self, title: T) -> Self
+    pub fn title<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.title = Some(title.into());
+        self.title = Some(value.into());
         self
     }
 
-    pub fn thumb<T>(mut self, thumb: T) -> Self
+    pub fn thumb<T>(mut self, value: T) -> Self
     where
         T: Into<InputFile>,
     {
-        self.thumb = Some(thumb.into());
+        self.thumb = Some(value.into());
         self
     }
 
-    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    pub fn disable_notification<T>(mut self, value: T) -> Self
     where
         T: Into<bool>,
     {
-        self.disable_notification = Some(disable_notification.into());
+        self.disable_notification = Some(value.into());
         self
     }
 
-    pub fn reply_to_message_id<T>(mut self, reply_to_message_id: T) -> Self
+    pub fn reply_to_message_id<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.reply_to_message_id = Some(reply_to_message_id.into());
+        self.reply_to_message_id = Some(value.into());
         self
     }
 }

--- a/src/requests/send_audio.rs
+++ b/src/requests/send_audio.rs
@@ -89,11 +89,13 @@ impl SendAudio<'_> {
                 "reply_to_message_id",
                 self.reply_to_message_id.as_ref(),
             );
+
         params = match self.audio {
             InputFile::File(file) => params.add_file("audio", &file),
             InputFile::Url(url) => params.add("audio", &url),
             InputFile::FileId(file_id) => params.add("audio", &file_id),
         };
+
         if let Some(thumb) = self.thumb {
             params = match thumb {
                 InputFile::File(file) => params.add_file("thumb", &file),
@@ -101,28 +103,31 @@ impl SendAudio<'_> {
                 InputFile::FileId(file_id) => params.add("thumb", &file_id),
             }
         }
-        let params = params.build();
 
         network::request_multipart(
             &self.ctx.client,
             &self.ctx.token,
             "sendAudio",
-            Some(params),
+            Some(params.build()),
         )
         .await
     }
 }
 
 impl<'a> SendAudio<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<C, A>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        audio: InputFile,
-    ) -> Self {
+        chat_id: C,
+        audio: A,
+    ) -> Self
+    where
+        C: Into<ChatId>,
+        A: Into<InputFile>,
+    {
         Self {
             ctx,
-            chat_id,
-            audio,
+            chat_id: chat_id.into(),
+            audio: audio.into(),
             caption: None,
             parse_mode: None,
             duration: None,
@@ -135,58 +140,82 @@ impl<'a> SendAudio<'a> {
         }
     }
 
-    pub fn chat_id<T: Into<ChatId>>(mut self, chat_id: T) -> Self {
+    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    where
+        T: Into<ChatId>,
+    {
         self.chat_id = chat_id.into();
         self
     }
 
-    pub fn audio<T: Into<InputFile>>(mut self, audio: T) -> Self {
+    pub fn audio<T>(mut self, audio: T) -> Self
+    where
+        T: Into<InputFile>,
+    {
         self.audio = audio.into();
         self
     }
 
-    pub fn caption<T: Into<String>>(mut self, caption: T) -> Self {
+    pub fn caption<T>(mut self, caption: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.caption = Some(caption.into());
         self
     }
 
-    pub fn parse_mode<T: Into<ParseMode>>(mut self, parse_mode: T) -> Self {
+    pub fn parse_mode<T>(mut self, parse_mode: T) -> Self
+    where
+        T: Into<ParseMode>,
+    {
         self.parse_mode = Some(parse_mode.into());
         self
     }
 
-    pub fn duration<T: Into<i32>>(mut self, duration: T) -> Self {
+    pub fn duration<T>(mut self, duration: T) -> Self
+    where
+        T: Into<i32>,
+    {
         self.duration = Some(duration.into());
         self
     }
 
-    pub fn performer<T: Into<String>>(mut self, performer: T) -> Self {
+    pub fn performer<T>(mut self, performer: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.performer = Some(performer.into());
         self
     }
 
-    pub fn title<T: Into<String>>(mut self, title: T) -> Self {
+    pub fn title<T>(mut self, title: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.title = Some(title.into());
         self
     }
 
-    pub fn thumb<T: Into<InputFile>>(mut self, thumb: T) -> Self {
+    pub fn thumb<T>(mut self, thumb: T) -> Self
+    where
+        T: Into<InputFile>,
+    {
         self.thumb = Some(thumb.into());
         self
     }
 
-    pub fn disable_notification<T: Into<bool>>(
-        mut self,
-        disable_notification: T,
-    ) -> Self {
+    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    where
+        T: Into<bool>,
+    {
         self.disable_notification = Some(disable_notification.into());
         self
     }
 
-    pub fn reply_to_message_id<T: Into<i32>>(
-        mut self,
-        reply_to_message_id: T,
-    ) -> Self {
+    pub fn reply_to_message_id<T>(mut self, reply_to_message_id: T) -> Self
+    where
+        T: Into<i32>,
+    {
         self.reply_to_message_id = Some(reply_to_message_id.into());
         self
     }

--- a/src/requests/send_chat_action.rs
+++ b/src/requests/send_chat_action.rs
@@ -47,15 +47,19 @@ impl SendChatAction<'_> {
 }
 
 impl<'a> SendChatAction<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<Cid, Ca>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        action: ChatAction,
-    ) -> Self {
+        chat_id: Cid,
+        action: Ca,
+    ) -> Self
+    where
+        Cid: Into<ChatId>,
+        Ca: Into<ChatAction>,
+    {
         Self {
             ctx,
-            chat_id,
-            action,
+            chat_id: chat_id.into(),
+            action: action.into(),
         }
     }
 

--- a/src/requests/send_chat_action.rs
+++ b/src/requests/send_chat_action.rs
@@ -63,19 +63,19 @@ impl<'a> SendChatAction<'a> {
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn action<T>(mut self, action: T) -> Self
+    pub fn action<T>(mut self, value: T) -> Self
     where
         T: Into<ChatAction>,
     {
-        self.action = action.into();
+        self.action = value.into();
         self
     }
 }

--- a/src/requests/send_contact.rs
+++ b/src/requests/send_contact.rs
@@ -64,17 +64,22 @@ impl SendContact<'_> {
 }
 
 impl<'a> SendContact<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<C, P, F>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        phone_number: String,
-        first_name: String,
-    ) -> Self {
+        chat_id: C,
+        phone_number: P,
+        first_name: F,
+    ) -> Self
+    where
+        C: Into<ChatId>,
+        P: Into<String>,
+        F: Into<String>,
+    {
         Self {
             ctx,
-            chat_id,
-            phone_number,
-            first_name,
+            chat_id: chat_id.into(),
+            phone_number: phone_number.into(),
+            first_name: first_name.into(),
             last_name: None,
             vcard: None,
             disable_notification: None,

--- a/src/requests/send_contact.rs
+++ b/src/requests/send_contact.rs
@@ -88,67 +88,67 @@ impl<'a> SendContact<'a> {
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn phone_number<T>(mut self, phone_number: T) -> Self
+    pub fn phone_number<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.phone_number = phone_number.into();
+        self.phone_number = value.into();
         self
     }
 
-    pub fn first_name<T>(mut self, first_name: T) -> Self
+    pub fn first_name<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.first_name = first_name.into();
+        self.first_name = value.into();
         self
     }
 
-    pub fn last_name<T>(mut self, last_name: T) -> Self
+    pub fn last_name<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.last_name = Some(last_name.into());
+        self.last_name = Some(value.into());
         self
     }
 
-    pub fn vcard<T>(mut self, vcard: T) -> Self
+    pub fn vcard<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.vcard = Some(vcard.into());
+        self.vcard = Some(value.into());
         self
     }
 
-    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    pub fn disable_notification<T>(mut self, value: T) -> Self
     where
         T: Into<bool>,
     {
-        self.disable_notification = Some(disable_notification.into());
+        self.disable_notification = Some(value.into());
         self
     }
 
-    pub fn reply_to_message_id<T>(mut self, reply_to_message_id: T) -> Self
+    pub fn reply_to_message_id<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.reply_to_message_id = Some(reply_to_message_id.into());
+        self.reply_to_message_id = Some(value.into());
         self
     }
 
-    pub fn reply_markup<T>(mut self, reply_markup: T) -> Self
+    pub fn reply_markup<T>(mut self, value: T) -> Self
     where
         T: Into<ReplyMarkup>,
     {
-        self.reply_markup = Some(reply_markup.into());
+        self.reply_markup = Some(value.into());
         self
     }
 }

--- a/src/requests/send_document.rs
+++ b/src/requests/send_document.rs
@@ -79,15 +79,19 @@ impl SendDocument<'_> {
 }
 
 impl<'a> SendDocument<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<C, D>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        document: String,
-    ) -> Self {
+        chat_id: C,
+        document: D,
+    ) -> Self
+    where
+        C: Into<ChatId>,
+        D: Into<String>,
+    {
         Self {
             ctx,
-            chat_id,
-            document,
+            chat_id: chat_id.into(),
+            document: document.into(),
             thumb: None,
             caption: None,
             parse_mode: None,

--- a/src/requests/send_document.rs
+++ b/src/requests/send_document.rs
@@ -101,67 +101,67 @@ impl<'a> SendDocument<'a> {
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn document<T>(mut self, document: T) -> Self
+    pub fn document<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.document = document.into();
+        self.document = value.into();
         self
     }
 
-    pub fn thumb<T>(mut self, thumb: T) -> Self
+    pub fn thumb<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.thumb = Some(thumb.into());
+        self.thumb = Some(value.into());
         self
     }
 
-    pub fn caption<T>(mut self, caption: T) -> Self
+    pub fn caption<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.caption = Some(caption.into());
+        self.caption = Some(value.into());
         self
     }
 
-    pub fn parse_mode<T>(mut self, parse_mode: T) -> Self
+    pub fn parse_mode<T>(mut self, value: T) -> Self
     where
         T: Into<ParseMode>,
     {
-        self.parse_mode = Some(parse_mode.into());
+        self.parse_mode = Some(value.into());
         self
     }
 
-    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    pub fn disable_notification<T>(mut self, value: T) -> Self
     where
         T: Into<bool>,
     {
-        self.disable_notification = Some(disable_notification.into());
+        self.disable_notification = Some(value.into());
         self
     }
 
-    pub fn reply_to_message_id<T>(mut self, reply_to_message_id: T) -> Self
+    pub fn reply_to_message_id<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.reply_to_message_id = Some(reply_to_message_id.into());
+        self.reply_to_message_id = Some(value.into());
         self
     }
 
-    pub fn reply_markup<T>(mut self, reply_markup: T) -> Self
+    pub fn reply_markup<T>(mut self, value: T) -> Self
     where
         T: Into<ReplyMarkup>,
     {
-        self.reply_markup = Some(reply_markup.into());
+        self.reply_markup = Some(value.into());
         self
     }
 }

--- a/src/requests/send_location.rs
+++ b/src/requests/send_location.rs
@@ -60,17 +60,22 @@ impl SendLocation<'_> {
 }
 
 impl<'a> SendLocation<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<Lt, Lg, C>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        latitude: f64,
-        longitude: f64,
-    ) -> Self {
+        chat_id: C,
+        latitude: Lt,
+        longitude: Lg,
+    ) -> Self
+    where
+        Lt: Into<f64>,
+        Lg: Into<f64>,
+        C: Into<ChatId>,
+    {
         Self {
             ctx,
-            chat_id,
-            latitude,
-            longitude,
+            chat_id: chat_id.into(),
+            latitude: latitude.into(),
+            longitude: longitude.into(),
             live_period: None,
             disable_notification: None,
             reply_to_message_id: None,
@@ -78,33 +83,51 @@ impl<'a> SendLocation<'a> {
         }
     }
 
-    pub fn chat_id<T: Into<ChatId>>(mut self, chat_id: T) -> Self {
+    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    where
+        T: Into<ChatId>,
+    {
         self.chat_id = chat_id.into();
         self
     }
 
-    pub fn latitude<T: Into<f64>>(mut self, latitude: T) -> Self {
+    pub fn latitude<Lt>(mut self, latitude: Lt) -> Self
+    where
+        Lt: Into<f64>,
+    {
         self.latitude = latitude.into();
         self
     }
 
-    pub fn longitude<T: Into<f64>>(mut self, longitude: T) -> Self {
+    pub fn longitude<Lg>(mut self, longitude: Lg) -> Self
+    where
+        Lg: Into<f64>,
+    {
         self.longitude = longitude.into();
         self
     }
 
-    pub fn live_period<T: Into<i32>>(mut self, live_period: T) -> Self {
+    pub fn live_period<T>(mut self, live_period: T) -> Self
+    where
+        T: Into<i32>,
+    {
         self.live_period = Some(live_period.into());
         self
     }
 
-    pub fn disable_notification<T: Into<bool>>(mut self, val: T) -> Self {
-        self.disable_notification = Some(val.into());
+    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    where
+        T: Into<bool>,
+    {
+        self.disable_notification = Some(disable_notification.into());
         self
     }
 
-    pub fn reply_to_message_id<T: Into<i32>>(mut self, val: T) -> Self {
-        self.reply_to_message_id = Some(val.into());
+    pub fn reply_to_message_id<T>(mut self, reply_to_message_id: T) -> Self
+    where
+        T: Into<i32>,
+    {
+        self.reply_to_message_id = Some(reply_to_message_id.into());
         self
     }
 }

--- a/src/requests/send_location.rs
+++ b/src/requests/send_location.rs
@@ -83,51 +83,51 @@ impl<'a> SendLocation<'a> {
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn latitude<Lt>(mut self, latitude: Lt) -> Self
+    pub fn latitude<Lt>(mut self, value: Lt) -> Self
     where
         Lt: Into<f64>,
     {
-        self.latitude = latitude.into();
+        self.latitude = value.into();
         self
     }
 
-    pub fn longitude<Lg>(mut self, longitude: Lg) -> Self
+    pub fn longitude<Lg>(mut self, value: Lg) -> Self
     where
         Lg: Into<f64>,
     {
-        self.longitude = longitude.into();
+        self.longitude = value.into();
         self
     }
 
-    pub fn live_period<T>(mut self, live_period: T) -> Self
+    pub fn live_period<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.live_period = Some(live_period.into());
+        self.live_period = Some(value.into());
         self
     }
 
-    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    pub fn disable_notification<T>(mut self, value: T) -> Self
     where
         T: Into<bool>,
     {
-        self.disable_notification = Some(disable_notification.into());
+        self.disable_notification = Some(value.into());
         self
     }
 
-    pub fn reply_to_message_id<T>(mut self, reply_to_message_id: T) -> Self
+    pub fn reply_to_message_id<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.reply_to_message_id = Some(reply_to_message_id.into());
+        self.reply_to_message_id = Some(value.into());
         self
     }
 }

--- a/src/requests/send_media_group.rs
+++ b/src/requests/send_media_group.rs
@@ -71,37 +71,53 @@ impl SendMediaGroup<'_> {
 }
 
 impl<'a> SendMediaGroup<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<C, M>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        media: Vec<InputMedia>,
-    ) -> Self {
+        chat_id: C,
+        media: M,
+    ) -> Self
+    where
+        C: Into<ChatId>,
+        M: Into<Vec<InputMedia>>,
+    {
         SendMediaGroup {
             ctx,
-            chat_id,
-            media,
+            chat_id: chat_id.into(),
+            media: media.into(),
             disable_notification: None,
             reply_to_message_id: None,
         }
     }
 
-    pub fn chat_id<T: Into<ChatId>>(mut self, val: T) -> Self {
-        self.chat_id = val.into();
+    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    where
+        T: Into<ChatId>,
+    {
+        self.chat_id = chat_id.into();
         self
     }
 
-    pub fn media<T: Into<Vec<InputMedia>>>(mut self, val: T) -> Self {
-        self.media = val.into();
+    pub fn media<T>(mut self, media: T) -> Self
+    where
+        T: Into<Vec<InputMedia>>,
+    {
+        self.media = media.into();
         self
     }
 
-    pub fn disable_notification<T: Into<bool>>(mut self, val: T) -> Self {
-        self.disable_notification = Some(val.into());
+    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    where
+        T: Into<bool>,
+    {
+        self.disable_notification = Some(disable_notification.into());
         self
     }
 
-    pub fn reply_to_message_id<T: Into<i32>>(mut self, val: T) -> Self {
-        self.reply_to_message_id = Some(val.into());
+    pub fn reply_to_message_id<T>(mut self, reply_to_message_id: T) -> Self
+    where
+        T: Into<i32>,
+    {
+        self.reply_to_message_id = Some(reply_to_message_id.into());
         self
     }
 }

--- a/src/requests/send_media_group.rs
+++ b/src/requests/send_media_group.rs
@@ -89,35 +89,35 @@ impl<'a> SendMediaGroup<'a> {
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn media<T>(mut self, media: T) -> Self
+    pub fn media<T>(mut self, value: T) -> Self
     where
         T: Into<Vec<InputMedia>>,
     {
-        self.media = media.into();
+        self.media = value.into();
         self
     }
 
-    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    pub fn disable_notification<T>(mut self, value: T) -> Self
     where
         T: Into<bool>,
     {
-        self.disable_notification = Some(disable_notification.into());
+        self.disable_notification = Some(value.into());
         self
     }
 
-    pub fn reply_to_message_id<T>(mut self, reply_to_message_id: T) -> Self
+    pub fn reply_to_message_id<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.reply_to_message_id = Some(reply_to_message_id.into());
+        self.reply_to_message_id = Some(value.into());
         self
     }
 }

--- a/src/requests/send_message.rs
+++ b/src/requests/send_message.rs
@@ -86,62 +86,59 @@ impl<'a> SendMessage<'a> {
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn text<T>(mut self, text: T) -> Self
+    pub fn text<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.text = text.into();
+        self.text = value.into();
         self
     }
 
-    pub fn parse_mode<T>(mut self, parse_mode: T) -> Self
+    pub fn parse_mode<T>(mut self, value: T) -> Self
     where
         T: Into<ParseMode>,
     {
-        self.parse_mode = Some(parse_mode.into());
+        self.parse_mode = Some(value.into());
         self
     }
 
-    pub fn disable_web_page_preview<T>(
-        mut self,
-        disable_web_page_preview: T,
-    ) -> Self
+    pub fn disable_web_page_preview<T>(mut self, value: T) -> Self
     where
         T: Into<bool>,
     {
-        self.disable_web_page_preview = Some(disable_web_page_preview.into());
+        self.disable_web_page_preview = Some(value.into());
         self
     }
 
-    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    pub fn disable_notification<T>(mut self, value: T) -> Self
     where
         T: Into<bool>,
     {
-        self.disable_notification = Some(disable_notification.into());
+        self.disable_notification = Some(value.into());
         self
     }
 
-    pub fn reply_to_message_id<T>(mut self, reply_to_message_id: T) -> Self
+    pub fn reply_to_message_id<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.reply_to_message_id = Some(reply_to_message_id.into());
+        self.reply_to_message_id = Some(value.into());
         self
     }
 
-    pub fn reply_markup<T>(mut self, reply_markup: T) -> Self
+    pub fn reply_markup<T>(mut self, value: T) -> Self
     where
         T: Into<ReplyMarkup>,
     {
-        self.reply_markup = Some(reply_markup.into());
+        self.reply_markup = Some(value.into());
         self
     }
 }

--- a/src/requests/send_message.rs
+++ b/src/requests/send_message.rs
@@ -65,15 +65,19 @@ impl SendMessage<'_> {
 }
 
 impl<'a> SendMessage<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<C, S>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        text: String,
-    ) -> Self {
+        chat_id: C,
+        text: S,
+    ) -> Self
+    where
+        C: Into<ChatId>,
+        S: Into<String>,
+    {
         SendMessage {
             ctx,
-            chat_id,
-            text,
+            chat_id: chat_id.into(),
+            text: text.into(),
             parse_mode: None,
             disable_web_page_preview: None,
             disable_notification: None,
@@ -82,38 +86,62 @@ impl<'a> SendMessage<'a> {
         }
     }
 
-    pub fn chat_id<T: Into<ChatId>>(mut self, val: T) -> Self {
-        self.chat_id = val.into();
+    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    where
+        T: Into<ChatId>,
+    {
+        self.chat_id = chat_id.into();
         self
     }
 
-    pub fn text<T: Into<String>>(mut self, val: T) -> Self {
-        self.text = val.into();
+    pub fn text<T>(mut self, text: T) -> Self
+    where
+        T: Into<String>,
+    {
+        self.text = text.into();
         self
     }
 
-    pub fn parse_mode<T: Into<ParseMode>>(mut self, val: T) -> Self {
-        self.parse_mode = Some(val.into());
+    pub fn parse_mode<T>(mut self, parse_mode: T) -> Self
+    where
+        T: Into<ParseMode>,
+    {
+        self.parse_mode = Some(parse_mode.into());
         self
     }
 
-    pub fn disable_web_page_preview<T: Into<bool>>(mut self, val: T) -> Self {
-        self.disable_web_page_preview = Some(val.into());
+    pub fn disable_web_page_preview<T>(
+        mut self,
+        disable_web_page_preview: T,
+    ) -> Self
+    where
+        T: Into<bool>,
+    {
+        self.disable_web_page_preview = Some(disable_web_page_preview.into());
         self
     }
 
-    pub fn disable_notification<T: Into<bool>>(mut self, val: T) -> Self {
-        self.disable_notification = Some(val.into());
+    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    where
+        T: Into<bool>,
+    {
+        self.disable_notification = Some(disable_notification.into());
         self
     }
 
-    pub fn reply_to_message_id<T: Into<i32>>(mut self, val: T) -> Self {
-        self.reply_to_message_id = Some(val.into());
+    pub fn reply_to_message_id<T>(mut self, reply_to_message_id: T) -> Self
+    where
+        T: Into<i32>,
+    {
+        self.reply_to_message_id = Some(reply_to_message_id.into());
         self
     }
 
-    pub fn reply_markup<T: Into<ReplyMarkup>>(mut self, val: T) -> Self {
-        self.reply_markup = Some(val.into());
+    pub fn reply_markup<T>(mut self, reply_markup: T) -> Self
+    where
+        T: Into<ReplyMarkup>,
+    {
+        self.reply_markup = Some(reply_markup.into());
         self
     }
 }

--- a/src/requests/send_photo.rs
+++ b/src/requests/send_photo.rs
@@ -73,28 +73,31 @@ impl SendPhoto<'_> {
             InputFile::Url(url) => params.add("photo", &url),
             InputFile::FileId(file_id) => params.add("photo", &file_id),
         };
-        let params = params.build();
 
         network::request_multipart(
             &self.ctx.client,
             &self.ctx.token,
             "sendPhoto",
-            Some(params),
+            Some(params.build()),
         )
         .await
     }
 }
 
 impl<'a> SendPhoto<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<C, P>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        photo: InputFile,
-    ) -> Self {
+        chat_id: C,
+        photo: P,
+    ) -> Self
+    where
+        C: Into<ChatId>,
+        P: Into<InputFile>,
+    {
         Self {
             ctx,
-            chat_id,
-            photo,
+            chat_id: chat_id.into(),
+            photo: photo.into(),
             caption: None,
             parse_mode: None,
             disable_notification: None,
@@ -103,38 +106,50 @@ impl<'a> SendPhoto<'a> {
         }
     }
 
-    pub fn chat_id<T: Into<ChatId>>(mut self, chat_id: T) -> Self {
+    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    where
+        T: Into<ChatId>,
+    {
         self.chat_id = chat_id.into();
         self
     }
 
-    pub fn photo<T: Into<InputFile>>(mut self, photo: T) -> Self {
+    pub fn photo<T>(mut self, photo: T) -> Self
+    where
+        T: Into<InputFile>,
+    {
         self.photo = photo.into();
         self
     }
 
-    pub fn caption<T: Into<String>>(mut self, caption: T) -> Self {
+    pub fn caption<T>(mut self, caption: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.caption = Some(caption.into());
         self
     }
 
-    pub fn parse_mode<T: Into<ParseMode>>(mut self, parse_mode: T) -> Self {
+    pub fn parse_mode<T>(mut self, parse_mode: T) -> Self
+    where
+        T: Into<ParseMode>,
+    {
         self.parse_mode = Some(parse_mode.into());
         self
     }
 
-    pub fn disable_notification<T: Into<bool>>(
-        mut self,
-        disable_notification: T,
-    ) -> Self {
+    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    where
+        T: Into<bool>,
+    {
         self.disable_notification = Some(disable_notification.into());
         self
     }
 
-    pub fn reply_to_message_id<T: Into<i32>>(
-        mut self,
-        reply_to_message_id: T,
-    ) -> Self {
+    pub fn reply_to_message_id<T>(mut self, reply_to_message_id: T) -> Self
+    where
+        T: Into<i32>,
+    {
         self.reply_to_message_id = Some(reply_to_message_id.into());
         self
     }

--- a/src/requests/send_photo.rs
+++ b/src/requests/send_photo.rs
@@ -106,51 +106,51 @@ impl<'a> SendPhoto<'a> {
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn photo<T>(mut self, photo: T) -> Self
+    pub fn photo<T>(mut self, value: T) -> Self
     where
         T: Into<InputFile>,
     {
-        self.photo = photo.into();
+        self.photo = value.into();
         self
     }
 
-    pub fn caption<T>(mut self, caption: T) -> Self
+    pub fn caption<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.caption = Some(caption.into());
+        self.caption = Some(value.into());
         self
     }
 
-    pub fn parse_mode<T>(mut self, parse_mode: T) -> Self
+    pub fn parse_mode<T>(mut self, value: T) -> Self
     where
         T: Into<ParseMode>,
     {
-        self.parse_mode = Some(parse_mode.into());
+        self.parse_mode = Some(value.into());
         self
     }
 
-    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    pub fn disable_notification<T>(mut self, value: T) -> Self
     where
         T: Into<bool>,
     {
-        self.disable_notification = Some(disable_notification.into());
+        self.disable_notification = Some(value.into());
         self
     }
 
-    pub fn reply_to_message_id<T>(mut self, reply_to_message_id: T) -> Self
+    pub fn reply_to_message_id<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.reply_to_message_id = Some(reply_to_message_id.into());
+        self.reply_to_message_id = Some(value.into());
         self
     }
 }

--- a/src/requests/send_poll.rs
+++ b/src/requests/send_poll.rs
@@ -54,17 +54,22 @@ impl SendPoll<'_> {
 }
 
 impl<'a> SendPoll<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<C, Q, O>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        question: String,
-        options: Vec<String>,
-    ) -> Self {
+        chat_id: C,
+        question: Q,
+        options: O,
+    ) -> Self
+    where
+        C: Into<ChatId>,
+        Q: Into<String>,
+        O: Into<Vec<String>>,
+    {
         Self {
             ctx,
-            chat_id,
-            question,
-            options,
+            chat_id: chat_id.into(),
+            question: question.into(),
+            options: options.into(),
             disable_notification: None,
             reply_to_message_id: None,
             reply_markup: None,

--- a/src/requests/send_poll.rs
+++ b/src/requests/send_poll.rs
@@ -76,51 +76,51 @@ impl<'a> SendPoll<'a> {
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn question<T>(mut self, question: T) -> Self
+    pub fn question<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.question = question.into();
+        self.question = value.into();
         self
     }
 
-    pub fn options<T>(mut self, options: T) -> Self
+    pub fn options<T>(mut self, value: T) -> Self
     where
         T: Into<Vec<String>>,
     {
-        self.options = options.into();
+        self.options = value.into();
         self
     }
 
-    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    pub fn disable_notification<T>(mut self, value: T) -> Self
     where
         T: Into<bool>,
     {
-        self.disable_notification = Some(disable_notification.into());
+        self.disable_notification = Some(value.into());
         self
     }
 
-    pub fn reply_to_message_id<T>(mut self, reply_to_message_id: T) -> Self
+    pub fn reply_to_message_id<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.reply_to_message_id = Some(reply_to_message_id.into());
+        self.reply_to_message_id = Some(value.into());
         self
     }
 
-    pub fn reply_markup<T>(mut self, reply_markup: T) -> Self
+    pub fn reply_markup<T>(mut self, value: T) -> Self
     where
         T: Into<ReplyMarkup>,
     {
-        self.reply_markup = Some(reply_markup.into());
+        self.reply_markup = Some(value.into());
         self
     }
 }

--- a/src/requests/send_venue.rs
+++ b/src/requests/send_venue.rs
@@ -98,75 +98,75 @@ impl<'a> SendVenue<'a> {
             reply_markup: None,
         }
     }
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn longitude<Lg>(mut self, longitude: Lg) -> Self
+    pub fn longitude<Lg>(mut self, value: Lg) -> Self
     where
         Lg: Into<f64>,
     {
-        self.longitude = longitude.into();
+        self.longitude = value.into();
         self
     }
 
-    pub fn latitude<Lt>(mut self, latitude: Lt) -> Self
+    pub fn latitude<Lt>(mut self, value: Lt) -> Self
     where
         Lt: Into<f64>,
     {
-        self.latitude = latitude.into();
+        self.latitude = value.into();
         self
     }
 
-    pub fn title<T>(mut self, title: T) -> Self
+    pub fn title<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.title = title.into();
+        self.title = value.into();
         self
     }
 
-    pub fn address<T>(mut self, address: T) -> Self
+    pub fn address<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.address = address.into();
+        self.address = value.into();
         self
     }
 
-    pub fn foursquare_id<T>(mut self, foursquare_id: T) -> Self
+    pub fn foursquare_id<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.foursquare_id = Some(foursquare_id.into());
+        self.foursquare_id = Some(value.into());
         self
     }
 
-    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    pub fn disable_notification<T>(mut self, value: T) -> Self
     where
         T: Into<bool>,
     {
-        self.disable_notification = Some(disable_notification.into());
+        self.disable_notification = Some(value.into());
         self
     }
 
-    pub fn foursquare_type<T>(mut self, foursquare_type: T) -> Self
+    pub fn foursquare_type<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.foursquare_type = Some(foursquare_type.into());
+        self.foursquare_type = Some(value.into());
         self
     }
 
-    pub fn reply_markup<T>(mut self, reply_markup: T) -> Self
+    pub fn reply_markup<T>(mut self, value: T) -> Self
     where
         T: Into<ReplyMarkup>,
     {
-        self.reply_markup = Some(reply_markup.into());
+        self.reply_markup = Some(value.into());
         self
     }
 }

--- a/src/requests/send_venue.rs
+++ b/src/requests/send_venue.rs
@@ -69,21 +69,28 @@ impl SendVenue<'_> {
 }
 
 impl<'a> SendVenue<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<Lt, Lg, C, T, A>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        latitude: f64,
-        longitude: f64,
-        title: String,
-        address: String,
-    ) -> Self {
+        chat_id: C,
+        latitude: Lt,
+        longitude: Lg,
+        title: T,
+        address: A,
+    ) -> Self
+    where
+        Lt: Into<f64>,
+        Lg: Into<f64>,
+        C: Into<ChatId>,
+        T: Into<String>,
+        A: Into<String>,
+    {
         Self {
             ctx,
-            chat_id,
-            latitude,
-            longitude,
-            title,
-            address,
+            chat_id: chat_id.into(),
+            latitude: latitude.into(),
+            longitude: longitude.into(),
+            title: title.into(),
+            address: address.into(),
             foursquare_id: None,
             foursquare_type: None,
             disable_notification: None,
@@ -99,17 +106,17 @@ impl<'a> SendVenue<'a> {
         self
     }
 
-    pub fn longitude<T>(mut self, longitude: T) -> Self
+    pub fn longitude<Lg>(mut self, longitude: Lg) -> Self
     where
-        T: Into<f64>,
+        Lg: Into<f64>,
     {
         self.longitude = longitude.into();
         self
     }
 
-    pub fn latitude<T>(mut self, latitude: T) -> Self
+    pub fn latitude<Lt>(mut self, latitude: Lt) -> Self
     where
-        T: Into<f64>,
+        Lt: Into<f64>,
     {
         self.latitude = latitude.into();
         self

--- a/src/requests/send_video.rs
+++ b/src/requests/send_video.rs
@@ -113,90 +113,90 @@ impl<'a> SendVideo<'a> {
             reply_markup: None,
         }
     }
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn video<T>(mut self, video: T) -> Self
+    pub fn video<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.video = video.into();
+        self.video = value.into();
         self
     }
 
-    pub fn duration<T>(mut self, duration: T) -> Self
+    pub fn duration<T>(mut self, value: T) -> Self
     where
         T: Into<u64>,
     {
-        self.duration = Some(duration.into());
+        self.duration = Some(value.into());
         self
     }
-    pub fn width<T>(mut self, width: T) -> Self
+    pub fn width<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.width = Some(width.into());
+        self.width = Some(value.into());
         self
     }
-    pub fn height<T>(mut self, height: T) -> Self
+    pub fn height<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.height = Some(height.into());
+        self.height = Some(value.into());
         self
     }
-    pub fn thumb<T>(mut self, thumb: T) -> Self
+    pub fn thumb<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.thumb = Some(thumb.into());
+        self.thumb = Some(value.into());
         self
     }
-    pub fn caption<T>(mut self, caption: T) -> Self
+    pub fn caption<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.caption = Some(caption.into());
+        self.caption = Some(value.into());
         self
     }
-    pub fn parse_mode<T>(mut self, parse_mode: T) -> Self
+    pub fn parse_mode<T>(mut self, value: T) -> Self
     where
         T: Into<ParseMode>,
     {
-        self.parse_mode = Some(parse_mode.into());
+        self.parse_mode = Some(value.into());
         self
     }
-    pub fn supports_streaming<T>(mut self, supports_streaming: T) -> Self
+    pub fn supports_streaming<T>(mut self, value: T) -> Self
     where
         T: Into<bool>,
     {
-        self.supports_streaming = Some(supports_streaming.into());
+        self.supports_streaming = Some(value.into());
         self
     }
-    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    pub fn disable_notification<T>(mut self, value: T) -> Self
     where
         T: Into<bool>,
     {
-        self.disable_notification = Some(disable_notification.into());
+        self.disable_notification = Some(value.into());
         self
     }
-    pub fn reply_to_message_id<T>(mut self, reply_to_message_id: T) -> Self
+    pub fn reply_to_message_id<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.reply_to_message_id = Some(reply_to_message_id.into());
+        self.reply_to_message_id = Some(value.into());
         self
     }
-    pub fn reply_markup<T>(mut self, reply_markup: T) -> Self
+    pub fn reply_markup<T>(mut self, value: T) -> Self
     where
         T: Into<ReplyMarkup>,
     {
-        self.reply_markup = Some(reply_markup.into());
+        self.reply_markup = Some(value.into());
         self
     }
 }

--- a/src/requests/send_video.rs
+++ b/src/requests/send_video.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use crate::network;
 use crate::requests::{Request, RequestContext, ResponseResult};
 use crate::types::{ChatId, Message, ParseMode, ReplyMarkup};
+
 //TODO: add action to bot api
 ///Use this method to send video files, Telegram clients support mp4 videos
 /// (other formats may be sent as Document). On success, the sent Message is
@@ -87,15 +88,19 @@ impl SendVideo<'_> {
 }
 
 impl<'a> SendVideo<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<C, V>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        video: String,
-    ) -> Self {
+        chat_id: C,
+        video: V,
+    ) -> Self
+    where
+        C: Into<ChatId>,
+        V: Into<String>,
+    {
         Self {
             ctx,
-            chat_id,
-            video,
+            chat_id: chat_id.into(),
+            video: video.into(),
             duration: None,
             width: None,
             height: None,

--- a/src/requests/send_video_note.rs
+++ b/src/requests/send_video_note.rs
@@ -97,67 +97,67 @@ impl<'a> SendVideoNote<'a> {
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn video_note<T>(mut self, video_note: T) -> Self
+    pub fn video_note<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.video_note = video_note.into();
+        self.video_note = value.into();
         self
     }
 
-    pub fn duration<T>(mut self, duration: T) -> Self
+    pub fn duration<T>(mut self, value: T) -> Self
     where
         T: Into<u64>,
     {
-        self.duration = Some(duration.into());
+        self.duration = Some(value.into());
         self
     }
 
-    pub fn length<T>(mut self, length: T) -> Self
+    pub fn length<T>(mut self, value: T) -> Self
     where
         T: Into<u64>,
     {
-        self.length = Some(length.into());
+        self.length = Some(value.into());
         self
     }
 
-    pub fn thumb<T>(mut self, thumb: T) -> Self
+    pub fn thumb<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.thumb = Some(thumb.into());
+        self.thumb = Some(value.into());
         self
     }
 
-    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    pub fn disable_notification<T>(mut self, value: T) -> Self
     where
         T: Into<bool>,
     {
-        self.disable_notification = Some(disable_notification.into());
+        self.disable_notification = Some(value.into());
         self
     }
 
-    pub fn reply_to_message_id<T>(mut self, reply_to_message_id: T) -> Self
+    pub fn reply_to_message_id<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.reply_to_message_id = Some(reply_to_message_id.into());
+        self.reply_to_message_id = Some(value.into());
         self
     }
 
-    pub fn reply_markup<T>(mut self, reply_markup: T) -> Self
+    pub fn reply_markup<T>(mut self, value: T) -> Self
     where
         T: Into<ReplyMarkup>,
     {
-        self.reply_markup = Some(reply_markup.into());
+        self.reply_markup = Some(value.into());
         self
     }
 }

--- a/src/requests/send_video_note.rs
+++ b/src/requests/send_video_note.rs
@@ -75,15 +75,19 @@ impl SendVideoNote<'_> {
 }
 
 impl<'a> SendVideoNote<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<C, V>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        video_note: String,
-    ) -> Self {
+        chat_id: C,
+        video_note: V,
+    ) -> Self
+    where
+        C: Into<ChatId>,
+        V: Into<String>,
+    {
         Self {
             ctx,
-            chat_id,
-            video_note,
+            chat_id: chat_id.into(),
+            video_note: video_note.into(),
             duration: None,
             length: None,
             thumb: None,

--- a/src/requests/send_voice.rs
+++ b/src/requests/send_voice.rs
@@ -94,67 +94,67 @@ impl<'a> SendVoice<'a> {
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn voice<T>(mut self, voice: T) -> Self
+    pub fn voice<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.voice = voice.into();
+        self.voice = value.into();
         self
     }
 
-    pub fn caption<T>(mut self, caption: T) -> Self
+    pub fn caption<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.caption = Some(caption.into());
+        self.caption = Some(value.into());
         self
     }
 
-    pub fn parse_mode<T>(mut self, parse_mode: T) -> Self
+    pub fn parse_mode<T>(mut self, value: T) -> Self
     where
         T: Into<ParseMode>,
     {
-        self.parse_mode = Some(parse_mode.into());
+        self.parse_mode = Some(value.into());
         self
     }
 
-    pub fn duration<T>(mut self, duration: T) -> Self
+    pub fn duration<T>(mut self, value: T) -> Self
     where
         T: Into<u64>,
     {
-        self.duration = Some(duration.into());
+        self.duration = Some(value.into());
         self
     }
 
-    pub fn disable_notification<T>(mut self, disable_notification: T) -> Self
+    pub fn disable_notification<T>(mut self, value: T) -> Self
     where
         T: Into<bool>,
     {
-        self.disable_notification = Some(disable_notification.into());
+        self.disable_notification = Some(value.into());
         self
     }
 
-    pub fn reply_to_message_id<T>(mut self, reply_to_message_id: T) -> Self
+    pub fn reply_to_message_id<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.reply_to_message_id = Some(reply_to_message_id.into());
+        self.reply_to_message_id = Some(value.into());
         self
     }
 
-    pub fn reply_markup<T>(mut self, reply_markup: T) -> Self
+    pub fn reply_markup<T>(mut self, value: T) -> Self
     where
         T: Into<ReplyMarkup>,
     {
-        self.reply_markup = Some(reply_markup.into());
+        self.reply_markup = Some(value.into());
         self
     }
 }

--- a/src/requests/send_voice.rs
+++ b/src/requests/send_voice.rs
@@ -72,15 +72,19 @@ impl SendVoice<'_> {
 }
 
 impl<'a> SendVoice<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<C, V>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        voice: String,
-    ) -> Self {
+        chat_id: C,
+        voice: V,
+    ) -> Self
+    where
+        C: Into<ChatId>,
+        V: Into<String>,
+    {
         Self {
             ctx,
-            chat_id,
-            voice,
+            chat_id: chat_id.into(),
+            voice: voice.into(),
             caption: None,
             parse_mode: None,
             duration: None,

--- a/src/requests/stop_message_live_location.rs
+++ b/src/requests/stop_message_live_location.rs
@@ -64,35 +64,35 @@ impl<'a> StopMessageLiveLocation<'a> {
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = Some(chat_id.into());
+        self.chat_id = Some(value.into());
         self
     }
 
-    pub fn message_id<T>(mut self, message_id: T) -> Self
+    pub fn message_id<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.message_id = Some(message_id.into());
+        self.message_id = Some(value.into());
         self
     }
 
-    pub fn inline_message_id<T>(mut self, inline_message_id: T) -> Self
+    pub fn inline_message_id<T>(mut self, value: T) -> Self
     where
         T: Into<String>,
     {
-        self.inline_message_id = Some(inline_message_id.into());
+        self.inline_message_id = Some(value.into());
         self
     }
 
-    pub fn reply_markup<T>(mut self, reply_markup: T) -> Self
+    pub fn reply_markup<T>(mut self, value: T) -> Self
     where
         T: Into<InlineKeyboardMarkup>,
     {
-        self.reply_markup = Some(reply_markup.into());
+        self.reply_markup = Some(value.into());
         self
     }
 }

--- a/src/requests/unban_chat_member.rs
+++ b/src/requests/unban_chat_member.rs
@@ -43,15 +43,19 @@ impl UnbanChatMember<'_> {
 }
 
 impl<'a> UnbanChatMember<'a> {
-    pub(crate) fn new(
+    pub(crate) fn new<C, U>(
         ctx: RequestContext<'a>,
-        chat_id: ChatId,
-        user_id: i32,
-    ) -> Self {
+        chat_id: C,
+        user_id: U,
+    ) -> Self
+    where
+        C: Into<ChatId>,
+        U: Into<i32>,
+    {
         Self {
             ctx,
-            chat_id,
-            user_id,
+            chat_id: chat_id.into(),
+            user_id: user_id.into(),
         }
     }
 

--- a/src/requests/unban_chat_member.rs
+++ b/src/requests/unban_chat_member.rs
@@ -59,19 +59,19 @@ impl<'a> UnbanChatMember<'a> {
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 
-    pub fn user_id<T>(mut self, user_id: T) -> Self
+    pub fn user_id<T>(mut self, value: T) -> Self
     where
         T: Into<i32>,
     {
-        self.user_id = user_id.into();
+        self.user_id = value.into();
         self
     }
 }

--- a/src/requests/unpin_chat_message.rs
+++ b/src/requests/unpin_chat_message.rs
@@ -36,21 +36,21 @@ impl UnpinChatMessage<'_> {
 }
 
 impl<'a> UnpinChatMessage<'a> {
-    pub(crate) fn new<C>(ctx: RequestContext<'a>, chat_id: C) -> Self
+    pub(crate) fn new<C>(ctx: RequestContext<'a>, value: C) -> Self
     where
         C: Into<ChatId>,
     {
         Self {
             ctx,
-            chat_id: chat_id.into(),
+            chat_id: value.into(),
         }
     }
 
-    pub fn chat_id<T>(mut self, chat_id: T) -> Self
+    pub fn chat_id<T>(mut self, value: T) -> Self
     where
         T: Into<ChatId>,
     {
-        self.chat_id = chat_id.into();
+        self.chat_id = value.into();
         self
     }
 }

--- a/src/requests/unpin_chat_message.rs
+++ b/src/requests/unpin_chat_message.rs
@@ -36,8 +36,14 @@ impl UnpinChatMessage<'_> {
 }
 
 impl<'a> UnpinChatMessage<'a> {
-    pub(crate) fn new(ctx: RequestContext<'a>, chat_id: ChatId) -> Self {
-        Self { ctx, chat_id }
+    pub(crate) fn new<C>(ctx: RequestContext<'a>, chat_id: C) -> Self
+    where
+        C: Into<ChatId>,
+    {
+        Self {
+            ctx,
+            chat_id: chat_id.into(),
+        }
     }
 
     pub fn chat_id<T>(mut self, chat_id: T) -> Self


### PR DESCRIPTION
 1. Use the `where` keyword instead of specifying generic parameters on the same line as a method name;
 2. Use `Into<T>` to accept parameters in `pub(crate) new` methods of the requests and remove lots of unnecessary `.into()` in `bot/api.rs`;
 3. Name parameters in the requests just `value` to eliminate duplication.