### PR TITLE
Fix some clippy warns

### DIFF
--- a/src/requests/forward_message.rs
+++ b/src/requests/forward_message.rs
@@ -70,6 +70,7 @@ impl<'a> ForwardMessage<'a> {
         self
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_chat_id<T: Into<ChatId>>(mut self, val: T) -> Self {
         self.from_chat_id = val.into();
         self

--- a/src/requests/kick_chat_member.rs
+++ b/src/requests/kick_chat_member.rs
@@ -28,7 +28,7 @@ pub struct KickChatMember<'a> {
 }
 
 #[async_trait]
-impl<'a> Request for KickChatMember<'a> {
+impl Request for KickChatMember<'_> {
     type ReturnValue = True;
 
     async fn send_boxed(self) -> ResponseResult<Self::ReturnValue> {

--- a/src/requests/pin_chat_message.rs
+++ b/src/requests/pin_chat_message.rs
@@ -45,7 +45,7 @@ impl<'a> PinChatMessage<'a> {
 }
 
 #[async_trait]
-impl<'a> Request for PinChatMessage<'a> {
+impl Request for PinChatMessage<'_> {
     type ReturnValue = True;
     async fn send_boxed(self) -> ResponseResult<Self::ReturnValue> {
         self.send().await

--- a/src/requests/restrict_chat_member.rs
+++ b/src/requests/restrict_chat_member.rs
@@ -29,7 +29,7 @@ pub struct RestrictChatMember<'a> {
 }
 
 #[async_trait]
-impl<'a> Request for RestrictChatMember<'a> {
+impl Request for RestrictChatMember<'_> {
     type ReturnValue = True;
 
     async fn send_boxed(self) -> ResponseResult<Self::ReturnValue> {

--- a/src/requests/send_animation.rs
+++ b/src/requests/send_animation.rs
@@ -65,7 +65,7 @@ pub struct SendAnimation<'a> {
 }
 
 #[async_trait]
-impl<'a> Request for SendAnimation<'a> {
+impl Request for SendAnimation<'_> {
     type ReturnValue = Message;
 
     async fn send_boxed(self) -> ResponseResult<Self::ReturnValue> {

--- a/src/requests/send_video.rs
+++ b/src/requests/send_video.rs
@@ -66,7 +66,7 @@ pub struct SendVideo<'a> {
 }
 
 #[async_trait]
-impl<'a> Request for SendVideo<'a> {
+impl Request for SendVideo<'_> {
     type ReturnValue = Message;
 
     async fn send_boxed(self) -> ResponseResult<Self::ReturnValue> {

--- a/src/requests/utils.rs
+++ b/src/requests/utils.rs
@@ -30,12 +30,11 @@ pub fn file_to_part(path_to_file: &PathBuf) -> Part {
             )
         })
         .flatten_stream();
-    let part = Part::stream(Body::wrap_stream(file)).file_name(
+    Part::stream(Body::wrap_stream(file)).file_name(
         path_to_file
             .file_name()
             .unwrap()
             .to_string_lossy()
             .into_owned(),
-    );
-    part
+    )
 }

--- a/src/types/inline_keyboard_button.rs
+++ b/src/types/inline_keyboard_button.rs
@@ -44,15 +44,13 @@ pub enum InlineKeyboardButtonKind {
 /// Build buttons
 ///
 /// Example:
-/// ```edition2018
+/// ```
 /// use async_telegram_bot::types::InlineKeyboardButton;
 ///
-/// fn main() {
-///     let url_button = InlineKeyboardButton::url(
-///         "Text".to_string(),
-///         "http://url.com".to_string(),
-///     );
-/// }
+/// let url_button = InlineKeyboardButton::url(
+///     "Text".to_string(),
+///     "http://url.com".to_string(),
+/// );
 /// ```
 impl InlineKeyboardButton {
     pub fn url(text: String, url: String) -> InlineKeyboardButton {

--- a/src/types/inline_keyboard_markup.rs
+++ b/src/types/inline_keyboard_markup.rs
@@ -5,7 +5,7 @@ use crate::types::InlineKeyboardButton;
 ///
 /// *Note*: This will only work in Telegram versions released after
 /// 9 April, 2016. Older clients will display unsupported message.
-#[derive(Debug, Serialize, Deserialize, Hash, PartialEq, Eq, Clone)]
+#[derive(Debug, Serialize, Deserialize, Hash, PartialEq, Eq, Clone, Default)]
 pub struct InlineKeyboardMarkup {
     /// Array of button rows, each represented by an Array of
     /// [`InlineKeyboardButton`] objects
@@ -28,9 +28,7 @@ pub struct InlineKeyboardMarkup {
 /// ```
 impl InlineKeyboardMarkup {
     pub fn new() -> Self {
-        Self {
-            inline_keyboard: vec![],
-        }
+        <_>::default()
     }
 
     pub fn append_row(mut self, buttons: Vec<InlineKeyboardButton>) -> Self {

--- a/src/types/unit_true.rs
+++ b/src/types/unit_true.rs
@@ -8,6 +8,7 @@ impl std::convert::TryFrom<bool> for True {
     type Error = ();
 
     fn try_from(value: bool) -> Result<Self, Self::Error> {
+        #[allow(clippy::match_bool)]
         match value {
             true => Ok(True),
             false => Err(()),
@@ -37,6 +38,7 @@ impl<'de> Visitor<'de> for TrueVisitor {
     where
         E: de::Error,
     {
+        #[allow(clippy::match_bool)]
         match value {
             true => Ok(True),
             false => Err(E::custom("expected `true`, found `false`")),


### PR DESCRIPTION
This PR does _not_ affect:
- "large size difference between variants" warnings (I'm not sure should we do smt with it)
- "method is never used: `new`" warnings (It's job for another pr that adds methods to `Bot`)